### PR TITLE
docs(planning): Sync AGENTS and Vercel roadmap #6

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,29 +1,40 @@
-# Kanban Project
+# Deep Workflow App - Agent Guide
 
 ## Business Requirements
 
-- TBD
+- Help a user plan and complete three personal deep-work sessions and one admin or must-do session each day.
+- Default each session to 45 minutes unless the product requirements explicitly change.
+- Keep daily sheets, goals, notes, timer state, and progress synced across laptops and phones.
+- Favor a calm, low-friction experience that supports focus instead of generic project-management complexity.
+- Ship the hosted app with Vercel as the default target for production and pull request preview environments.
 
 ## Technical Details
 
-- TBD
+- Follow the roadmap in `plan.md`: Django, PostgreSQL, Django templates with HTMX and Alpine.js, Tailwind CSS, and Vercel for hosting.
+- Keep the timer server-backed via timestamps so refreshes and device switching do not lose session state.
+- Prefer server-rendered flows and simple abstractions; only add client-side behavior where it materially improves the experience.
+- Cover core workflow logic and persistence with automated tests, and use integration or end-to-end tests for critical user flows.
+- Keep documentation concise and consistent across `README.md`, `plan.md`, and this file when product or hosting assumptions change.
 
-## Color Scheme
+## UX Guidance
 
-- TBD
+- Use a low-distraction, mobile-friendly interface that works well on both laptops and phones.
+- Make the next important action obvious: planning a session, starting the timer, updating notes, or marking work complete.
+- Avoid visually noisy patterns, unnecessary animation, and clutter that would interrupt focus.
+- Keep status, progress, and timing information clear and accessible.
 
 ## Strategy
 
-1. Write plan with success criteria for each phase to be checked off. Include project scaffolding, including .gitignore, and rigorous unit testing.
-2. Execute the plan ensuring all criteria are met
-3. Carry out extensive integration testing with Playwright or similar, fixing defects
-4. Only complete when the MVP is finished and tested, with the server running and ready for the user
+1. Write a concrete implementation plan with success criteria for each phase, including project scaffolding, basic documentation, and rigorous testing.
+2. Execute the plan in small, reviewable pull requests that keep scope tight and preserve momentum.
+3. Carry out integration testing with Playwright or a similar tool for the most important end-to-end flows, fixing defects before calling the MVP done.
+4. Only consider the MVP complete when the app is finished, tested, and ready to run for real users in the hosted environment.
 
 ## Coding standards
 
-1. Use latest versions of libraries and idiomatic approaches as of today
-2. Keep it simple - NEVER over-engineer, ALWAYS simplify, NO unnecessary defensive programming. No extra features - focus on simplicity.
-3. Be concise. Keep README minimal. IMPORTANT: no emojis ever
+1. Use current stable libraries and idiomatic approaches that fit the repository's chosen stack.
+2. Keep it simple - NEVER over-engineer, ALWAYS simplify, and avoid unnecessary defensive programming or speculative features.
+3. Be concise. Keep the README minimal, focused, and free of emojis.
 
 # AI Coding Assistant Instructions
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ To keep the first version simple and fast to iterate on, the recommended stack i
 - PostgreSQL
 - Django templates with HTMX and Alpine.js
 - Tailwind CSS
+- Vercel for production hosting and pull request preview deployments
 
-This keeps the app strongly Python-first while still leaving room for a modern, responsive UI.
+This keeps the app strongly Python-first while still leaving room for a modern, responsive UI. For the detailed hosting roadmap and deployment expectations, see `plan.md`, especially PR 9.
 
 ## Roadmap
 
@@ -48,4 +49,4 @@ The implementation should land in small, reviewable PRs:
 6. add the synced 45-minute session timer
 7. auto-generate daily sheets and add progress summaries
 8. polish the mobile UX and add PWA basics
-9. prepare production deployment, backups, and monitoring
+9. prepare Vercel deployment, backups, and monitoring

--- a/plan.md
+++ b/plan.md
@@ -20,6 +20,8 @@ Recommended stack for v1:
 - Tailwind CSS for responsive, polished UI
 - Vercel for production hosting and pull request preview deployments
 
+Keep `README.md`'s stack summary aligned with this section. Detailed hosting guidance for Vercel production and PR previews lives in this plan, especially PR 9 below.
+
 Why this stack:
 
 - Django gives auth, ORM, migrations, admin, forms, and deployment maturity out of the box
@@ -53,7 +55,7 @@ Assumptions for MVP:
 
   - added a product brief for the deep-workflow app
   - defined MVP scope, non-goals, and success criteria
-  - documented the recommended stack: Django + PostgreSQL + HTMX/Alpine + Tailwind
+  - documented the recommended stack: Django + PostgreSQL + HTMX/Alpine + Tailwind + Vercel
   - captured the phased PR roadmap for implementation
 
   ## Acceptance criteria


### PR DESCRIPTION
## Summary
- replace AGENTS.md with the canonical contents from mathemage/mathemage
- update plan.md to make Vercel the expected hosting target
- clarify that production and PR previews should both be hosted on Vercel

## Testing
- not run (documentation-only changes)

Closes #6