### PR TITLE
feat(sheet): Build the responsive daily sheet UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The implementation should land in small, reviewable PRs:
 
 ## Current foundation
 
-This repository now includes the first five implementation slices from the roadmap:
+This repository now includes the foundation plus roadmap slices 1 through 5:
 
 - Django project and `core` app wiring
 - environment-based settings with `DATABASE_URL` support for PostgreSQL

--- a/README.md
+++ b/README.md
@@ -84,16 +84,17 @@ The implementation should land in small, reviewable PRs:
 
 ## Current foundation
 
-This repository now includes the first four implementation slices from the roadmap:
+This repository now includes the first five implementation slices from the roadmap:
 
 - Django project and `core` app wiring
 - environment-based settings with `DATABASE_URL` support for PostgreSQL
 - login/logout with protected app routes
 - per-user timezone and default session duration settings
 - daily sheet and work session domain models with migrations, admin registration, and tests
+- a responsive daily sheet UI with previous/next day navigation and per-session goal, notes, and status editing
 - Ruff linting/formatting, pytest-based tests, and GitHub Actions CI
 
-The follow-up roadmap items still apply; this foundation intentionally stops short of the daily sheet UI, timer behavior, and progress summaries.
+The follow-up roadmap items still apply; this foundation intentionally stops short of synced timer behavior and progress summaries.
 
 ## Local development
 
@@ -114,7 +115,7 @@ python manage.py createsuperuser
 python manage.py runserver
 ```
 
-The app will be available at `http://127.0.0.1:8000/`. Sign in at `http://127.0.0.1:8000/login/`, then use the settings page to choose your timezone and default session duration. The health endpoint remains available at `http://127.0.0.1:8000/health/`.
+The app will be available at `http://127.0.0.1:8000/`. Sign in at `http://127.0.0.1:8000/login/`, then use the daily sheet to plan or update the four session cards. The settings page still lets you choose your timezone and default session duration. The health endpoint remains available at `http://127.0.0.1:8000/health/`.
 
 ### PostgreSQL configuration
 

--- a/core/forms.py
+++ b/core/forms.py
@@ -2,7 +2,7 @@ from zoneinfo import available_timezones
 
 from django import forms
 
-from .models import UserPreferences, validate_timezone_name
+from .models import UserPreferences, WorkSession, validate_timezone_name
 
 TIMEZONE_OPTIONS = tuple(sorted(available_timezones()))
 
@@ -42,3 +42,27 @@ class UserPreferencesForm(forms.ModelForm):
         value = self.cleaned_data["timezone"].strip()
         validate_timezone_name(value)
         return value
+
+
+class WorkSessionUpdateForm(forms.ModelForm):
+    class Meta:
+        model = WorkSession
+        fields = ("goal", "notes", "status")
+        help_texts = {
+            "goal": "Keep it concrete and finishable.",
+            "notes": "Optional context, blockers, or follow-up notes.",
+            "status": (
+                "Reflect whether the session is planned, active, completed, or skipped."
+            ),
+        }
+        widgets = {
+            "goal": forms.TextInput(
+                attrs={"placeholder": "What would make this session feel complete?"}
+            ),
+            "notes": forms.Textarea(
+                attrs={
+                    "placeholder": "Capture context, reminders, or next steps.",
+                    "rows": 4,
+                }
+            ),
+        }

--- a/core/tests/test_daily_sheet_views.py
+++ b/core/tests/test_daily_sheet_views.py
@@ -1,0 +1,139 @@
+from datetime import date
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from pytest_django.asserts import assertContains, assertTemplateUsed
+
+from core.models import DailySheet, UserPreferences, WorkSession
+
+
+@pytest.fixture
+def user(db):
+    return get_user_model().objects.create_user(
+        username="jules",
+        password="calm-focus-123",
+    )
+
+
+def test_home_renders_daily_sheet_for_today(client, user) -> None:
+    client.force_login(user)
+
+    response = client.get(reverse("home"))
+
+    assert response.status_code == 200
+    assertTemplateUsed(response, "core/home.html")
+    assert response.context["is_today"] is True
+    assert UserPreferences.objects.filter(user=user).exists()
+    assert DailySheet.objects.filter(
+        user=user,
+        sheet_date=response.context["selected_date"],
+    ).exists()
+    assert [card["session"].slot for card in response.context["session_cards"]] == [
+        WorkSession.Slot.PERSONAL_1,
+        WorkSession.Slot.PERSONAL_2,
+        WorkSession.Slot.PERSONAL_3,
+        WorkSession.Slot.ADMIN,
+    ]
+    assertContains(response, "Personal 1")
+    assertContains(response, "Admin")
+    assertContains(response, "Previous day")
+    assertContains(response, "Next day")
+
+
+def test_home_loads_selected_day_and_navigation(client, user) -> None:
+    client.force_login(user)
+    selected_date = date(2026, 4, 5)
+
+    response = client.get(reverse("home"), {"date": selected_date.isoformat()})
+
+    assert response.status_code == 200
+    assert response.context["selected_date"] == selected_date
+    assert response.context["previous_date"] == date(2026, 4, 4)
+    assert response.context["next_date"] == date(2026, 4, 6)
+    assert response.context["is_today"] is False
+    assert DailySheet.objects.filter(user=user, sheet_date=selected_date).exists()
+    assertContains(response, "?date=2026-04-04")
+    assertContains(response, "?date=2026-04-06")
+
+
+def test_home_rejects_invalid_selected_day(client, user) -> None:
+    client.force_login(user)
+
+    response = client.get(reverse("home"), {"date": "not-a-date"})
+
+    assert response.status_code == 404
+
+
+def test_home_updates_work_session_fields(client, user) -> None:
+    client.force_login(user)
+    sheet = DailySheet.objects.create(user=user, sheet_date=date(2026, 4, 5))
+    session = sheet.work_sessions.get(slot=WorkSession.Slot.PERSONAL_2)
+
+    response = client.post(
+        f"{reverse('home')}?date={sheet.sheet_date.isoformat()}",
+        {
+            "session_id": str(session.pk),
+            f"session-{session.pk}-goal": "Ship the card layout",
+            f"session-{session.pk}-notes": "Keep the copy calm and focused.",
+            f"session-{session.pk}-status": WorkSession.Status.ACTIVE,
+        },
+        follow=True,
+    )
+
+    assert response.status_code == 200
+    assertContains(response, "Personal 2 saved.")
+
+    session.refresh_from_db()
+    assert session.goal == "Ship the card layout"
+    assert session.notes == "Keep the copy calm and focused."
+    assert session.status == WorkSession.Status.ACTIVE
+
+
+def test_home_shows_errors_for_invalid_session_update(client, user) -> None:
+    client.force_login(user)
+    sheet = DailySheet.objects.create(user=user, sheet_date=date(2026, 4, 5))
+    session = sheet.work_sessions.get(slot=WorkSession.Slot.ADMIN)
+
+    response = client.post(
+        f"{reverse('home')}?date={sheet.sheet_date.isoformat()}",
+        {
+            "session_id": str(session.pk),
+            f"session-{session.pk}-goal": "g" * 256,
+            f"session-{session.pk}-notes": "Document the loose ends.",
+            f"session-{session.pk}-status": WorkSession.Status.PLANNED,
+        },
+    )
+
+    assert response.status_code == 200
+    assertContains(response, "Ensure this value has at most 255 characters")
+
+    session.refresh_from_db()
+    assert session.goal == ""
+    assert session.notes == ""
+    assert session.status == WorkSession.Status.PLANNED
+
+
+def test_home_cannot_update_another_users_session(client, user) -> None:
+    other_user = get_user_model().objects.create_user(
+        username="river",
+        password="calm-focus-123",
+    )
+    other_sheet = DailySheet.objects.create(
+        user=other_user,
+        sheet_date=date(2026, 4, 5),
+    )
+    other_session = other_sheet.work_sessions.get(slot=WorkSession.Slot.PERSONAL_1)
+    client.force_login(user)
+
+    response = client.post(
+        reverse("home"),
+        {
+            "session_id": str(other_session.pk),
+            f"session-{other_session.pk}-goal": "Intrude on another account",
+            f"session-{other_session.pk}-notes": "This should never work.",
+            f"session-{other_session.pk}-status": WorkSession.Status.COMPLETED,
+        },
+    )
+
+    assert response.status_code == 404

--- a/core/tests/test_daily_sheet_views.py
+++ b/core/tests/test_daily_sheet_views.py
@@ -57,6 +57,15 @@ def test_home_loads_selected_day_and_navigation(client, user) -> None:
     assertContains(response, "?date=2026-04-06")
 
 
+def test_home_strips_whitespace_from_selected_day(client, user) -> None:
+    client.force_login(user)
+
+    response = client.get(reverse("home"), {"date": "2026-04-05 "})
+
+    assert response.status_code == 200
+    assert response.context["selected_date"] == date(2026, 4, 5)
+
+
 def test_home_rejects_invalid_selected_day(client, user) -> None:
     client.force_login(user)
 
@@ -106,7 +115,12 @@ def test_home_shows_errors_for_invalid_session_update(client, user) -> None:
     )
 
     assert response.status_code == 200
-    assertContains(response, "Ensure this value has at most 255 characters")
+    session_card = next(
+        card
+        for card in response.context["session_cards"]
+        if card["session"].pk == session.pk
+    )
+    assert "goal" in session_card["form"].errors
 
     session.refresh_from_db()
     assert session.goal == ""

--- a/core/views.py
+++ b/core/views.py
@@ -23,8 +23,10 @@ def resolve_sheet_date(request: HttpRequest) -> date:
     if not raw_date:
         return timezone.localdate()
 
+    normalized_date = raw_date.strip()
+
     try:
-        return date.fromisoformat(raw_date)
+        return date.fromisoformat(normalized_date)
     except ValueError as exc:
         raise Http404("Invalid daily sheet date.") from exc
 

--- a/core/views.py
+++ b/core/views.py
@@ -1,11 +1,15 @@
+from datetime import date, timedelta
+
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.views import LoginView
-from django.http import HttpRequest, HttpResponse, JsonResponse
-from django.shortcuts import redirect, render
+from django.http import Http404, HttpRequest, HttpResponse, JsonResponse
+from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse
+from django.utils import timezone
 
-from .forms import UserPreferencesForm
-from .models import UserPreferences
+from .forms import UserPreferencesForm, WorkSessionUpdateForm
+from .models import DailySheet, UserPreferences, WorkSession
 
 
 class DeepWorkflowLoginView(LoginView):
@@ -13,10 +17,103 @@ class DeepWorkflowLoginView(LoginView):
     redirect_authenticated_user = True
 
 
+def resolve_sheet_date(request: HttpRequest) -> date:
+    raw_date = request.GET.get("date")
+
+    if not raw_date:
+        return timezone.localdate()
+
+    try:
+        return date.fromisoformat(raw_date)
+    except ValueError as exc:
+        raise Http404("Invalid daily sheet date.") from exc
+
+
+def get_daily_sheet(user, sheet_date: date) -> tuple[DailySheet, list[WorkSession]]:
+    sheet, _ = DailySheet.objects.get_or_create(user=user, sheet_date=sheet_date)
+    sessions = list(sheet.work_sessions.order_by("slot"))
+    return sheet, sessions
+
+
+def build_session_cards(
+    sessions: list[WorkSession],
+    *,
+    bound_form: WorkSessionUpdateForm | None = None,
+) -> list[dict[str, object]]:
+    session_cards = []
+
+    for session in sessions:
+        prefix = f"session-{session.pk}"
+        form = (
+            bound_form
+            if bound_form is not None and bound_form.instance.pk == session.pk
+            else WorkSessionUpdateForm(instance=session, prefix=prefix)
+        )
+        session_cards.append({"session": session, "form": form})
+
+    return session_cards
+
+
+def build_home_context(
+    user,
+    preferences: UserPreferences,
+    sheet_date: date,
+    *,
+    bound_form: WorkSessionUpdateForm | None = None,
+) -> dict[str, object]:
+    sheet, sessions = get_daily_sheet(user, sheet_date)
+    today = timezone.localdate()
+
+    return {
+        "preferences": preferences,
+        "sheet": sheet,
+        "selected_date": sheet.sheet_date,
+        "previous_date": sheet.sheet_date - timedelta(days=1),
+        "next_date": sheet.sheet_date + timedelta(days=1),
+        "is_today": sheet.sheet_date == today,
+        "session_cards": build_session_cards(sessions, bound_form=bound_form),
+    }
+
+
 @login_required
 def home(request: HttpRequest) -> HttpResponse:
     preferences = UserPreferences.for_user(request.user)
-    return render(request, "core/home.html", {"preferences": preferences})
+
+    if request.method == "POST":
+        try:
+            session_id = int(request.POST["session_id"])
+        except (KeyError, ValueError) as exc:
+            raise Http404("Session not found.") from exc
+
+        session = get_object_or_404(
+            WorkSession.objects.select_related("daily_sheet"),
+            pk=session_id,
+            daily_sheet__user=request.user,
+        )
+        form = WorkSessionUpdateForm(
+            request.POST,
+            instance=session,
+            prefix=f"session-{session.pk}",
+        )
+
+        if form.is_valid():
+            form.save()
+            messages.success(request, f"{session.get_slot_display()} saved.")
+            return redirect(
+                f"{reverse('home')}?date={session.daily_sheet.sheet_date.isoformat()}"
+                f"#session-{session.slot}"
+            )
+
+        context = build_home_context(
+            request.user,
+            preferences,
+            session.daily_sheet.sheet_date,
+            bound_form=form,
+        )
+        return render(request, "core/home.html", context)
+
+    context = build_home_context(request.user, preferences, resolve_sheet_date(request))
+    return render(request, "core/home.html", context)
 
 
 @login_required

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -51,7 +51,7 @@ body {
 }
 
 .site-main {
-  max-width: 48rem;
+  max-width: 64rem;
   margin: 0 auto;
   padding: 2rem 1.5rem 3rem;
 }
@@ -108,12 +108,14 @@ label {
 }
 
 input,
+textarea,
 select,
 button {
   font: inherit;
 }
 
 input,
+textarea,
 select {
   width: 100%;
   box-sizing: border-box;
@@ -125,6 +127,7 @@ select {
 }
 
 input:focus,
+textarea:focus,
 select:focus,
 button:focus {
   outline: 2px solid #93c5fd;
@@ -203,6 +206,16 @@ button:focus {
   background: #1e293b;
 }
 
+.button-secondary {
+  border: 1px solid #cbd5e1;
+  background: #ffffff;
+  color: #0f172a;
+}
+
+.button-secondary:hover {
+  background: #f8fafc;
+}
+
 .button-link {
   padding: 0;
   border: 0;
@@ -235,6 +248,151 @@ button:focus {
   font-weight: 600;
 }
 
+.sheet-layout {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.sheet-header {
+  display: grid;
+  gap: 1rem;
+}
+
+.sheet-header-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.sheet-date {
+  margin: 0;
+  color: #475569;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.sheet-nav {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.sheet-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+}
+
+.session-card {
+  display: grid;
+  gap: 1rem;
+}
+
+.session-card-personal {
+  border-top: 0.35rem solid #38bdf8;
+}
+
+.session-card-admin {
+  border-top: 0.35rem solid #f59e0b;
+}
+
+.session-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.session-card-header h2,
+.session-section h3 {
+  margin: 0;
+}
+
+.session-card-header h2 {
+  margin-top: 0.25rem;
+  font-size: 1.4rem;
+  line-height: 1.2;
+}
+
+.session-meta {
+  margin: 0.35rem 0 0;
+  color: #475569;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.status-badge-planned {
+  background: #e2e8f0;
+  color: #334155;
+}
+
+.status-badge-active {
+  background: #dbeafe;
+  color: #1d4ed8;
+}
+
+.status-badge-completed {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.status-badge-skipped {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.session-summary {
+  display: grid;
+  gap: 1rem;
+}
+
+.session-section {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.session-section h3 {
+  color: #475569;
+  font-size: 0.9rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.empty-copy {
+  color: #64748b;
+  font-style: italic;
+}
+
+.text-block {
+  white-space: pre-wrap;
+}
+
+.session-editor {
+  padding-top: 1rem;
+  border-top: 1px solid #e2e8f0;
+}
+
+.session-editor summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.session-editor[open] summary {
+  margin-bottom: 1rem;
+}
+
 @media (max-width: 640px) {
   .site-header {
     padding-inline: 1rem;
@@ -246,6 +404,10 @@ button:focus {
 
   .header-inner {
     align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .session-card-header {
     flex-direction: column;
   }
 }

--- a/templates/core/home.html
+++ b/templates/core/home.html
@@ -1,32 +1,108 @@
 {% extends "base.html" %}
 
-{% block title %}Dashboard | deep-workflow{% endblock title %}
+{% block title %}Daily sheet | deep-workflow{% endblock title %}
 
 {% block content %}
-  <section class="card stack-large">
-    <span class="eyebrow">Dashboard</span>
-    <h1>Ready for focused work.</h1>
-    <p>
-      You are signed in as <strong>{{ request.user.get_username }}</strong>. This
-      account now has the minimum settings the app needs before the daily sheet
-      and timer land in follow-up PRs.
-    </p>
-    <dl class="details">
-      <div>
-        <dt>Timezone</dt>
-        <dd>{{ preferences.timezone }}</dd>
+  <section class="sheet-layout">
+    <div class="card sheet-header">
+      <div class="sheet-header-top">
+        <div class="sheet-heading">
+          <span class="eyebrow">Daily sheet</span>
+          <h1>{% if is_today %}Today{% else %}{{ selected_date|date:"l, F j" }}{% endif %}</h1>
+          <p class="sheet-date">{{ selected_date|date:"l, F j, Y" }}</p>
+        </div>
+        <div class="sheet-nav" aria-label="Day navigation">
+          <a class="button button-secondary" href="{% url 'home' %}?date={{ previous_date|date:'Y-m-d' }}">
+            Previous day
+          </a>
+          {% if not is_today %}
+            <a class="button button-secondary" href="{% url 'home' %}">Today</a>
+          {% endif %}
+          <a class="button button-secondary" href="{% url 'home' %}?date={{ next_date|date:'Y-m-d' }}">
+            Next day
+          </a>
+        </div>
       </div>
-      <div>
-        <dt>Default session duration</dt>
-        <dd>{{ preferences.default_session_duration_minutes }} minutes</dd>
-      </div>
-    </dl>
-    <p class="muted">
-      Confirm these defaults now so future session planning stays consistent
-      across devices.
-    </p>
-    <div class="actions">
-      <a class="button" href="{% url 'preferences' %}">Edit settings</a>
+      <p class="muted">
+        Plan three personal sessions and one admin block. This screen stays
+        focused on goal, notes, and status while timer behavior lands in a
+        follow-up PR.
+      </p>
+      <dl class="details">
+        <div>
+          <dt>Timezone</dt>
+          <dd>{{ preferences.timezone }}</dd>
+        </div>
+        <div>
+          <dt>Default session duration</dt>
+          <dd>{{ preferences.default_session_duration_minutes }} minutes</dd>
+        </div>
+      </dl>
+    </div>
+
+    <div class="sheet-grid">
+      {% for card in session_cards %}
+        {% with session=card.session form=card.form %}
+          <article id="session-{{ session.slot }}" class="card session-card session-card-{{ session.category }}">
+            <div class="session-card-header">
+              <div>
+                <span class="eyebrow">{{ session.get_category_display }} session</span>
+                <h2>{{ session.get_slot_display }}</h2>
+                <p class="session-meta">Current status: {{ session.get_status_display }}</p>
+              </div>
+              <span class="status-badge status-badge-{{ session.status }}">{{ session.get_status_display }}</span>
+            </div>
+
+            <div class="session-summary">
+              <section class="session-section">
+                <h3>Goal</h3>
+                {% if session.goal %}
+                  <p>{{ session.goal }}</p>
+                {% else %}
+                  <p class="empty-copy">Add a finishable outcome for this block.</p>
+                {% endif %}
+              </section>
+
+              <section class="session-section">
+                <h3>Notes</h3>
+                {% if session.notes %}
+                  <p class="text-block">{{ session.notes }}</p>
+                {% else %}
+                  <p class="empty-copy">Keep context, reminders, or blockers here.</p>
+                {% endif %}
+              </section>
+            </div>
+
+            <details class="session-editor"{% if form.errors %} open{% endif %}>
+              <summary>{% if session.goal or session.notes %}Edit session{% else %}Plan session{% endif %}</summary>
+              <form method="post" action="{% url 'home' %}?date={{ selected_date|date:'Y-m-d' }}" class="stack-large">
+                {% csrf_token %}
+                <input type="hidden" name="session_id" value="{{ session.pk }}">
+                {% if form.non_field_errors %}
+                  <div class="message message-error">
+                    {{ form.non_field_errors }}
+                  </div>
+                {% endif %}
+                {% for field in form %}
+                  <div class="field">
+                    <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+                    {{ field }}
+                    {% if field.help_text %}
+                      <p class="help">{{ field.help_text }}</p>
+                    {% endif %}
+                    {% for error in field.errors %}
+                      <p class="error">{{ error }}</p>
+                    {% endfor %}
+                  </div>
+                {% endfor %}
+                <div class="actions">
+                  <button type="submit" class="button">Save {{ session.get_slot_display }}</button>
+                </div>
+              </form>
+            </details>
+          </article>
+        {% endwith %}
+      {% endfor %}
     </div>
   </section>
 {% endblock content %}

--- a/templates/core/home.html
+++ b/templates/core/home.html
@@ -11,7 +11,7 @@
           <h1>{% if is_today %}Today{% else %}{{ selected_date|date:"l, F j" }}{% endif %}</h1>
           <p class="sheet-date">{{ selected_date|date:"l, F j, Y" }}</p>
         </div>
-        <div class="sheet-nav" aria-label="Day navigation">
+        <nav class="sheet-nav" aria-label="Day navigation">
           <a class="button button-secondary" href="{% url 'home' %}?date={{ previous_date|date:'Y-m-d' }}">
             Previous day
           </a>
@@ -21,7 +21,7 @@
           <a class="button button-secondary" href="{% url 'home' %}?date={{ next_date|date:'Y-m-d' }}">
             Next day
           </a>
-        </div>
+        </nav>
       </div>
       <p class="muted">
         Plan three personal sessions and one admin block. This screen stays


### PR DESCRIPTION
## Why

Once the data model exists, the next most important step is a usable daily screen that works well on both laptop and phone.

## What changed

- added the main daily sheet page
- rendered 3 personal session cards and 1 admin session card for a selected day
- added create/edit interactions for goals, notes, and status
- made the layout responsive for mobile and desktop

## Acceptance criteria

- a signed-in user can view today's sheet
- session cards are easy to use on small screens
- goals, notes, and status can be edited without admin access

## Out of scope

- live countdown timer
- reporting dashboards

---

closes #16 
