### PR TITLE
feat(rules): Auto-generate daily sheets and add progress summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The implementation should land in small, reviewable PRs:
 
 ## Current foundation
 
-This repository now includes the foundation plus roadmap slices 1 through 6:
+This repository now includes the foundation plus roadmap slices 1 through 7:
 
 - Django project and `core` app wiring
 - environment-based settings with `DATABASE_URL` support for PostgreSQL
@@ -93,9 +93,11 @@ This repository now includes the foundation plus roadmap slices 1 through 6:
 - daily sheet and work session domain models with migrations, admin registration, and tests
 - a responsive daily sheet UI with previous/next day navigation plus per-session goal and notes editing
 - a server-backed session timer with start, pause, resume, and complete actions plus remaining-time feedback
+- auto-generated daily sheets that keep the fixed 3 personal + 1 admin structure intact
+- daily and weekly progress summaries with simple streak and completion indicators
 - Ruff linting/formatting, pytest-based tests, and GitHub Actions CI
 
-The follow-up roadmap items still apply; this foundation now includes the synced timer flow and intentionally stops short of progress summaries.
+The follow-up roadmap items still apply; this foundation now includes progress summaries and intentionally stops short of mobile/PWA polish and deployment work.
 
 ## Local development
 

--- a/core/models.py
+++ b/core/models.py
@@ -47,6 +47,7 @@ WORK_SESSION_PERSONAL_SLOTS = tuple(
     if category == WorkSessionCategory.PERSONAL
 )
 WORK_SESSION_CATEGORY_BY_SLOT = dict(WORK_SESSION_DEFAULT_STRUCTURE)
+WORK_SESSION_DEFAULT_SLOTS = frozenset(WORK_SESSION_CATEGORY_BY_SLOT)
 
 
 class UserPreferences(models.Model):
@@ -108,9 +109,19 @@ class DailySheet(models.Model):
             self.ensure_default_work_sessions()
 
     def ensure_default_work_sessions(self) -> None:
+        existing_slots = set(self.work_sessions.values_list("slot", flat=True))
+        missing_structure = [
+            (slot, category)
+            for slot, category in WorkSession.DEFAULT_STRUCTURE
+            if slot not in existing_slots
+        ]
+
+        if not missing_structure and existing_slots == WORK_SESSION_DEFAULT_SLOTS:
+            return
+
         preferences = UserPreferences.for_user(self.user)
 
-        for slot, category in WorkSession.DEFAULT_STRUCTURE:
+        for slot, category in missing_structure:
             WorkSession.objects.get_or_create(
                 daily_sheet=self,
                 slot=slot,

--- a/core/models.py
+++ b/core/models.py
@@ -108,8 +108,13 @@ class DailySheet(models.Model):
             super().save(*args, **kwargs)
             self.ensure_default_work_sessions()
 
-    def ensure_default_work_sessions(self) -> None:
-        existing_slots = set(self.work_sessions.values_list("slot", flat=True))
+    def ensure_default_work_sessions(
+        self,
+        *,
+        existing_slots: set[int] | None = None,
+    ) -> None:
+        if existing_slots is None:
+            existing_slots = set(self.work_sessions.values_list("slot", flat=True))
         missing_structure = [
             (slot, category)
             for slot, category in WorkSession.DEFAULT_STRUCTURE

--- a/core/tests/test_daily_sheet_views.py
+++ b/core/tests/test_daily_sheet_views.py
@@ -120,6 +120,23 @@ def test_home_repairs_missing_default_session_structure(client, user) -> None:
     assert repaired_sheet.work_sessions.count() == 4
 
 
+def test_home_skips_slot_repair_queries_when_structure_is_already_healthy(
+    client,
+    user,
+) -> None:
+    client.force_login(user)
+    sheet = DailySheet.objects.create(user=user, sheet_date=date(2026, 4, 5))
+
+    with patch.object(
+        WorkSession.objects,
+        "get_or_create",
+        side_effect=AssertionError("Healthy sheets should not need slot repair."),
+    ):
+        response = client.get(reverse("home"), {"date": sheet.sheet_date.isoformat()})
+
+    assert response.status_code == 200
+
+
 def test_home_builds_daily_and_weekly_completion_summaries(client, user) -> None:
     client.force_login(user)
     selected_date = date(2026, 4, 8)
@@ -193,6 +210,67 @@ def test_home_streak_breaks_when_the_previous_day_has_no_completed_sessions(
     )
 
     response = client.get(reverse("home"), {"date": selected_date.isoformat()})
+
+    assert response.status_code == 200
+    assert response.context["weekly_summary"]["streak_days"] == 1
+
+
+def test_home_streak_extends_before_the_current_week(client, user) -> None:
+    client.force_login(user)
+    selected_date = date(2026, 4, 8)
+    sunday_sheet = DailySheet.objects.create(user=user, sheet_date=date(2026, 4, 5))
+    monday_sheet = DailySheet.objects.create(user=user, sheet_date=date(2026, 4, 6))
+    tuesday_sheet = DailySheet.objects.create(user=user, sheet_date=date(2026, 4, 7))
+    wednesday_sheet = DailySheet.objects.create(user=user, sheet_date=selected_date)
+
+    complete_session(
+        sunday_sheet.work_sessions.get(slot=WorkSession.Slot.PERSONAL_1),
+        start_time=datetime(2026, 4, 5, 9, 0, tzinfo=dt_timezone.utc),
+    )
+    complete_session(
+        monday_sheet.work_sessions.get(slot=WorkSession.Slot.PERSONAL_1),
+        start_time=datetime(2026, 4, 6, 9, 0, tzinfo=dt_timezone.utc),
+    )
+    complete_session(
+        tuesday_sheet.work_sessions.get(slot=WorkSession.Slot.PERSONAL_1),
+        start_time=datetime(2026, 4, 7, 9, 0, tzinfo=dt_timezone.utc),
+    )
+    complete_session(
+        wednesday_sheet.work_sessions.get(slot=WorkSession.Slot.PERSONAL_1),
+        start_time=datetime(2026, 4, 8, 9, 0, tzinfo=dt_timezone.utc),
+    )
+
+    response = client.get(reverse("home"), {"date": selected_date.isoformat()})
+
+    assert response.status_code == 200
+    assert response.context["weekly_summary"]["streak_days"] == 4
+
+
+def test_home_streak_avoids_older_history_query_when_gap_is_in_current_week(
+    client,
+    user,
+) -> None:
+    client.force_login(user)
+    selected_date = date(2026, 4, 8)
+    monday_sheet = DailySheet.objects.create(user=user, sheet_date=date(2026, 4, 6))
+    wednesday_sheet = DailySheet.objects.create(user=user, sheet_date=selected_date)
+
+    complete_session(
+        monday_sheet.work_sessions.get(slot=WorkSession.Slot.PERSONAL_1),
+        start_time=datetime(2026, 4, 6, 9, 0, tzinfo=dt_timezone.utc),
+    )
+    complete_session(
+        wednesday_sheet.work_sessions.get(slot=WorkSession.Slot.PERSONAL_1),
+        start_time=datetime(2026, 4, 8, 9, 0, tzinfo=dt_timezone.utc),
+    )
+
+    with patch(
+        "core.views.completed_sheet_dates_desc",
+        side_effect=AssertionError(
+            "A current-week gap should end the streak without older history work."
+        ),
+    ):
+        response = client.get(reverse("home"), {"date": selected_date.isoformat()})
 
     assert response.status_code == 200
     assert response.context["weekly_summary"]["streak_days"] == 1

--- a/core/tests/test_daily_sheet_views.py
+++ b/core/tests/test_daily_sheet_views.py
@@ -19,6 +19,11 @@ def user(db):
     )
 
 
+def complete_session(session: WorkSession, *, start_time: datetime) -> None:
+    session.start(now=start_time)
+    session.complete(now=start_time + timedelta(minutes=session.duration_minutes))
+
+
 def test_home_renders_daily_sheet_for_today(client, user) -> None:
     client.force_login(user)
 
@@ -42,6 +47,23 @@ def test_home_renders_daily_sheet_for_today(client, user) -> None:
     assertContains(response, "Admin")
     assertContains(response, "Previous day")
     assertContains(response, "Next day")
+
+
+def test_home_uses_user_timezone_to_pick_todays_sheet(client, user) -> None:
+    UserPreferences.objects.create(user=user, timezone="America/Los_Angeles")
+    client.force_login(user)
+    current_time = datetime(2026, 4, 6, 6, 30, tzinfo=dt_timezone.utc)
+
+    with patch("core.views.timezone.now", return_value=current_time):
+        response = client.get(reverse("home"))
+
+    assert response.status_code == 200
+    assert response.context["selected_date"] == date(2026, 4, 5)
+    assert DailySheet.objects.filter(user=user, sheet_date=date(2026, 4, 5)).exists()
+    assert not DailySheet.objects.filter(
+        user=user,
+        sheet_date=date(2026, 4, 6),
+    ).exists()
 
 
 def test_home_loads_selected_day_and_navigation(client, user) -> None:
@@ -75,6 +97,105 @@ def test_home_rejects_invalid_selected_day(client, user) -> None:
     response = client.get(reverse("home"), {"date": "not-a-date"})
 
     assert response.status_code == 404
+
+
+def test_home_repairs_missing_default_session_structure(client, user) -> None:
+    selected_date = date(2026, 4, 5)
+    DailySheet.objects.bulk_create([DailySheet(user=user, sheet_date=selected_date)])
+    sheet = DailySheet.objects.get(user=user, sheet_date=selected_date)
+    client.force_login(user)
+
+    assert sheet.work_sessions.count() == 0
+
+    response = client.get(reverse("home"), {"date": selected_date.isoformat()})
+
+    assert response.status_code == 200
+    assert [card["session"].slot for card in response.context["session_cards"]] == [
+        WorkSession.Slot.PERSONAL_1,
+        WorkSession.Slot.PERSONAL_2,
+        WorkSession.Slot.PERSONAL_3,
+        WorkSession.Slot.ADMIN,
+    ]
+    repaired_sheet = DailySheet.objects.get(user=user, sheet_date=selected_date)
+    assert repaired_sheet.work_sessions.count() == 4
+
+
+def test_home_builds_daily_and_weekly_completion_summaries(client, user) -> None:
+    client.force_login(user)
+    selected_date = date(2026, 4, 8)
+
+    monday_sheet = DailySheet.objects.create(user=user, sheet_date=date(2026, 4, 6))
+    tuesday_sheet = DailySheet.objects.create(user=user, sheet_date=date(2026, 4, 7))
+    wednesday_sheet = DailySheet.objects.create(user=user, sheet_date=selected_date)
+
+    monday_start = datetime(2026, 4, 6, 9, 0, tzinfo=dt_timezone.utc)
+    for index, session in enumerate(monday_sheet.work_sessions.order_by("slot")):
+        complete_session(
+            session,
+            start_time=monday_start + timedelta(hours=index),
+        )
+
+    complete_session(
+        tuesday_sheet.work_sessions.get(slot=WorkSession.Slot.PERSONAL_1),
+        start_time=datetime(2026, 4, 7, 9, 0, tzinfo=dt_timezone.utc),
+    )
+    complete_session(
+        wednesday_sheet.work_sessions.get(slot=WorkSession.Slot.PERSONAL_1),
+        start_time=datetime(2026, 4, 8, 9, 0, tzinfo=dt_timezone.utc),
+    )
+    complete_session(
+        wednesday_sheet.work_sessions.get(slot=WorkSession.Slot.PERSONAL_2),
+        start_time=datetime(2026, 4, 8, 10, 0, tzinfo=dt_timezone.utc),
+    )
+
+    response = client.get(reverse("home"), {"date": selected_date.isoformat()})
+
+    assert response.status_code == 200
+    assertContains(response, "Daily completion")
+    assertContains(response, "Weekly completion")
+    assertContains(response, "Consistency")
+    assert response.context["daily_summary"] == {
+        "total_sessions": 4,
+        "completed_sessions": 2,
+        "completion_percentage": 50,
+        "in_progress_sessions": 0,
+        "open_sessions": 2,
+        "skipped_sessions": 0,
+    }
+    assert response.context["weekly_summary"] == {
+        "week_start": date(2026, 4, 6),
+        "week_end": date(2026, 4, 12),
+        "completed_sessions": 7,
+        "total_sessions": 28,
+        "completion_percentage": 25,
+        "focused_days": 3,
+        "completed_days": 1,
+        "streak_days": 3,
+    }
+
+
+def test_home_streak_breaks_when_the_previous_day_has_no_completed_sessions(
+    client,
+    user,
+) -> None:
+    client.force_login(user)
+    selected_date = date(2026, 4, 8)
+    monday_sheet = DailySheet.objects.create(user=user, sheet_date=date(2026, 4, 6))
+    wednesday_sheet = DailySheet.objects.create(user=user, sheet_date=selected_date)
+
+    complete_session(
+        monday_sheet.work_sessions.get(slot=WorkSession.Slot.PERSONAL_1),
+        start_time=datetime(2026, 4, 6, 9, 0, tzinfo=dt_timezone.utc),
+    )
+    complete_session(
+        wednesday_sheet.work_sessions.get(slot=WorkSession.Slot.PERSONAL_1),
+        start_time=datetime(2026, 4, 8, 9, 0, tzinfo=dt_timezone.utc),
+    )
+
+    response = client.get(reverse("home"), {"date": selected_date.isoformat()})
+
+    assert response.status_code == 200
+    assert response.context["weekly_summary"]["streak_days"] == 1
 
 
 def test_home_updates_work_session_fields(client, user) -> None:

--- a/core/tests/test_daily_sheet_views.py
+++ b/core/tests/test_daily_sheet_views.py
@@ -47,6 +47,7 @@ def test_home_renders_daily_sheet_for_today(client, user) -> None:
     assertContains(response, "Admin")
     assertContains(response, "Previous day")
     assertContains(response, "Next day")
+    assertContains(response, "completed today")
 
 
 def test_home_uses_user_timezone_to_pick_todays_sheet(client, user) -> None:
@@ -80,6 +81,7 @@ def test_home_loads_selected_day_and_navigation(client, user) -> None:
     assert DailySheet.objects.filter(user=user, sheet_date=selected_date).exists()
     assertContains(response, "?date=2026-04-04")
     assertContains(response, "?date=2026-04-06")
+    assertContains(response, "completed on this day")
 
 
 def test_home_strips_whitespace_from_selected_day(client, user) -> None:

--- a/core/tests/test_daily_sheet_views.py
+++ b/core/tests/test_daily_sheet_views.py
@@ -128,8 +128,8 @@ def test_home_skips_slot_repair_queries_when_structure_is_already_healthy(
     sheet = DailySheet.objects.create(user=user, sheet_date=date(2026, 4, 5))
 
     with patch.object(
-        WorkSession.objects,
-        "get_or_create",
+        DailySheet,
+        "ensure_default_work_sessions",
         side_effect=AssertionError("Healthy sheets should not need slot repair."),
     ):
         response = client.get(reverse("home"), {"date": sheet.sheet_date.isoformat()})

--- a/core/tests/test_daily_sheet_views.py
+++ b/core/tests/test_daily_sheet_views.py
@@ -9,6 +9,7 @@ from django.urls import reverse
 from pytest_django.asserts import assertContains, assertTemplateUsed
 
 from core.models import DailySheet, UserPreferences, WorkSession
+from core.views import completion_percentage
 
 
 @pytest.fixture
@@ -22,6 +23,15 @@ def user(db):
 def complete_session(session: WorkSession, *, start_time: datetime) -> None:
     session.start(now=start_time)
     session.complete(now=start_time + timedelta(minutes=session.duration_minutes))
+
+
+def test_completion_percentage_uses_round_half_up() -> None:
+    assert completion_percentage(1, 8) == 13
+
+
+def test_completion_percentage_clamps_to_0_and_100() -> None:
+    assert completion_percentage(-1, 4) == 0
+    assert completion_percentage(5, 4) == 100
 
 
 def test_home_renders_daily_sheet_for_today(client, user) -> None:

--- a/core/views.py
+++ b/core/views.py
@@ -57,8 +57,9 @@ def resolve_sheet_date(request: HttpRequest) -> date:
 
 
 def get_daily_sheet(user, sheet_date: date) -> tuple[DailySheet, list[WorkSession]]:
-    sheet, _ = DailySheet.objects.get_or_create(user=user, sheet_date=sheet_date)
-    sheet.ensure_default_work_sessions()
+    sheet, created = DailySheet.objects.get_or_create(user=user, sheet_date=sheet_date)
+    if not created:
+        sheet.ensure_default_work_sessions()
     sessions = list(sheet.work_sessions.order_by("slot"))
     return sheet, sessions
 
@@ -212,12 +213,44 @@ def completed_sessions_by_date(
     )
 
 
-def build_completion_streak(user, *, anchor_date: date) -> int:
-    completed_lookup = completed_sessions_by_date(user, end_date=anchor_date)
+def completed_sheet_dates_desc(user, *, end_date: date):
+    return (
+        DailySheet.objects.filter(user=user, sheet_date__lte=end_date)
+        .annotate(
+            completed_sessions=Count(
+                "work_sessions",
+                filter=Q(work_sessions__status=WorkSession.Status.COMPLETED),
+            )
+        )
+        .filter(completed_sessions__gt=0)
+        .order_by("-sheet_date")
+        .values_list("sheet_date", flat=True)
+    )
+
+
+def build_completion_streak(
+    user,
+    *,
+    anchor_date: date,
+    recent_completed_lookup: dict[date, int] | None = None,
+    recent_start_date: date | None = None,
+) -> int:
     streak_days = 0
     current_date = anchor_date
 
-    while completed_lookup.get(current_date, 0) > 0:
+    if recent_completed_lookup is not None and recent_start_date is not None:
+        while current_date >= recent_start_date:
+            if recent_completed_lookup.get(current_date, 0) == 0:
+                return streak_days
+            streak_days += 1
+            current_date -= timedelta(days=1)
+
+    for completed_date in completed_sheet_dates_desc(
+        user,
+        end_date=current_date,
+    ).iterator():
+        if completed_date != current_date:
+            break
         streak_days += 1
         current_date -= timedelta(days=1)
 
@@ -254,7 +287,12 @@ def build_weekly_summary(user, *, anchor_date: date) -> dict[str, object]:
             for week_date in week_dates
             if completed_lookup.get(week_date, 0) == daily_target
         ),
-        "streak_days": build_completion_streak(user, anchor_date=anchor_date),
+        "streak_days": build_completion_streak(
+            user,
+            anchor_date=anchor_date,
+            recent_completed_lookup=completed_lookup,
+            recent_start_date=week_start,
+        ),
     }
 
 

--- a/core/views.py
+++ b/core/views.py
@@ -166,7 +166,10 @@ def completion_percentage(completed_sessions: int, total_sessions: int) -> int:
     if total_sessions <= 0:
         return 0
 
-    return round((completed_sessions / total_sessions) * 100)
+    rounded_percentage = ((completed_sessions * 200) + total_sessions) // (
+        2 * total_sessions
+    )
+    return max(0, min(rounded_percentage, 100))
 
 
 def build_daily_summary(sessions: list[WorkSession]) -> dict[str, int]:

--- a/core/views.py
+++ b/core/views.py
@@ -57,10 +57,14 @@ def resolve_sheet_date(request: HttpRequest) -> date:
 
 
 def get_daily_sheet(user, sheet_date: date) -> tuple[DailySheet, list[WorkSession]]:
-    sheet, created = DailySheet.objects.get_or_create(user=user, sheet_date=sheet_date)
-    if not created:
-        sheet.ensure_default_work_sessions()
+    sheet, _ = DailySheet.objects.get_or_create(user=user, sheet_date=sheet_date)
     sessions = list(sheet.work_sessions.order_by("slot"))
+    existing_slots = {session.slot for session in sessions}
+
+    if existing_slots != set(slot for slot, _ in WorkSession.DEFAULT_STRUCTURE):
+        sheet.ensure_default_work_sessions(existing_slots=existing_slots)
+        sessions = list(sheet.work_sessions.order_by("slot"))
+
     return sheet, sessions
 
 

--- a/core/views.py
+++ b/core/views.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from datetime import date, datetime, timedelta
 
 from django.contrib import messages
@@ -5,6 +6,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.views import LoginView
 from django.core.exceptions import ValidationError
 from django.db import transaction
+from django.db.models import Count, Q
 from django.http import Http404, HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
@@ -56,6 +58,7 @@ def resolve_sheet_date(request: HttpRequest) -> date:
 
 def get_daily_sheet(user, sheet_date: date) -> tuple[DailySheet, list[WorkSession]]:
     sheet, _ = DailySheet.objects.get_or_create(user=user, sheet_date=sheet_date)
+    sheet.ensure_default_work_sessions()
     sessions = list(sheet.work_sessions.order_by("slot"))
     return sheet, sessions
 
@@ -154,6 +157,107 @@ def build_session_cards(
     return session_cards
 
 
+def completion_percentage(completed_sessions: int, total_sessions: int) -> int:
+    if total_sessions <= 0:
+        return 0
+
+    return round((completed_sessions / total_sessions) * 100)
+
+
+def build_daily_summary(sessions: list[WorkSession]) -> dict[str, int]:
+    total_sessions = len(WorkSession.DEFAULT_STRUCTURE)
+    status_counts = Counter(session.status for session in sessions)
+    completed_sessions = status_counts[WorkSession.Status.COMPLETED]
+    active_sessions = status_counts[WorkSession.Status.ACTIVE]
+    paused_sessions = status_counts[WorkSession.Status.PAUSED]
+    planned_sessions = status_counts[WorkSession.Status.PLANNED]
+    skipped_sessions = status_counts[WorkSession.Status.SKIPPED]
+
+    return {
+        "total_sessions": total_sessions,
+        "completed_sessions": completed_sessions,
+        "completion_percentage": completion_percentage(
+            completed_sessions,
+            total_sessions,
+        ),
+        "in_progress_sessions": active_sessions + paused_sessions,
+        "open_sessions": active_sessions + paused_sessions + planned_sessions,
+        "skipped_sessions": skipped_sessions,
+    }
+
+
+def completed_sessions_by_date(
+    user,
+    *,
+    end_date: date,
+    start_date: date | None = None,
+) -> dict[date, int]:
+    filters: dict[str, object] = {
+        "user": user,
+        "sheet_date__lte": end_date,
+    }
+    if start_date is not None:
+        filters["sheet_date__gte"] = start_date
+
+    return dict(
+        DailySheet.objects.filter(**filters)
+        .annotate(
+            completed_sessions=Count(
+                "work_sessions",
+                filter=Q(work_sessions__status=WorkSession.Status.COMPLETED),
+            )
+        )
+        .filter(completed_sessions__gt=0)
+        .values_list("sheet_date", "completed_sessions")
+    )
+
+
+def build_completion_streak(user, *, anchor_date: date) -> int:
+    completed_lookup = completed_sessions_by_date(user, end_date=anchor_date)
+    streak_days = 0
+    current_date = anchor_date
+
+    while completed_lookup.get(current_date, 0) > 0:
+        streak_days += 1
+        current_date -= timedelta(days=1)
+
+    return streak_days
+
+
+def build_weekly_summary(user, *, anchor_date: date) -> dict[str, object]:
+    week_start = anchor_date - timedelta(days=anchor_date.weekday())
+    week_end = week_start + timedelta(days=6)
+    completed_lookup = completed_sessions_by_date(
+        user,
+        start_date=week_start,
+        end_date=week_end,
+    )
+    daily_target = len(WorkSession.DEFAULT_STRUCTURE)
+    weekly_target = daily_target * 7
+    week_dates = [week_start + timedelta(days=offset) for offset in range(7)]
+    completed_sessions = sum(completed_lookup.values())
+
+    return {
+        "week_start": week_start,
+        "week_end": week_end,
+        "completed_sessions": completed_sessions,
+        "total_sessions": weekly_target,
+        "completion_percentage": completion_percentage(
+            completed_sessions,
+            weekly_target,
+        ),
+        "focused_days": sum(
+            1 for week_date in week_dates if completed_lookup.get(week_date, 0) > 0
+        ),
+        "completed_days": sum(
+            1
+            for week_date in week_dates
+            if completed_lookup.get(week_date, 0) == daily_target
+        ),
+        "streak_days": build_completion_streak(user, anchor_date=anchor_date),
+    }
+
+
 def build_home_context(
     user,
     preferences: UserPreferences,
@@ -164,6 +268,8 @@ def build_home_context(
     sheet, sessions = get_daily_sheet(user, sheet_date)
     today = timezone.localdate()
     now = timezone.now()
+    daily_summary = build_daily_summary(sessions)
+    weekly_summary = build_weekly_summary(user, anchor_date=sheet.sheet_date)
 
     return {
         "preferences": preferences,
@@ -172,6 +278,8 @@ def build_home_context(
         "previous_date": sheet.sheet_date - timedelta(days=1),
         "next_date": sheet.sheet_date + timedelta(days=1),
         "is_today": sheet.sheet_date == today,
+        "daily_summary": daily_summary,
+        "weekly_summary": weekly_summary,
         "session_cards": build_session_cards(
             sessions,
             bound_form=bound_form,

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -298,6 +298,85 @@ button:focus {
   grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
 }
 
+.summary-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+}
+
+.summary-card {
+  display: grid;
+  gap: 1rem;
+}
+
+.summary-card-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.summary-card h2 {
+  margin: 0.25rem 0 0;
+  font-size: clamp(2rem, 6vw, 2.5rem);
+  line-height: 1;
+}
+
+.summary-copy,
+.summary-range {
+  margin: 0.75rem 0 0;
+  color: #475569;
+}
+
+.summary-range {
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.summary-metric {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 3.5rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  background: #e0f2fe;
+  color: #0369a1;
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.progress-track {
+  height: 0.75rem;
+  border-radius: 999px;
+  background: #e2e8f0;
+  overflow: hidden;
+}
+
+.progress-fill {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #38bdf8 0%, #0f172a 100%);
+}
+
+.summary-stats {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.summary-stats dt {
+  color: #475569;
+  font-size: 0.9rem;
+}
+
+.summary-stats dd {
+  margin-top: 0.25rem;
+  font-size: 1.15rem;
+  font-weight: 700;
+}
+
 .session-card {
   display: grid;
   gap: 1rem;
@@ -469,7 +548,12 @@ button:focus {
     flex-direction: column;
   }
 
+  .summary-card-top,
   .session-timer-top {
     flex-direction: column;
+  }
+
+  .summary-stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }

--- a/templates/core/home.html
+++ b/templates/core/home.html
@@ -40,6 +40,99 @@
       </dl>
     </div>
 
+    <div class="summary-grid">
+      <section class="card summary-card" aria-labelledby="daily-summary-title">
+        <div class="summary-card-top">
+          <div>
+            <span class="eyebrow">Daily completion</span>
+            <h2 id="daily-summary-title">{{ daily_summary.completed_sessions }}/{{ daily_summary.total_sessions }}</h2>
+            <p class="summary-copy">
+              {{ daily_summary.completed_sessions }} session{{ daily_summary.completed_sessions|pluralize }} completed today{% if daily_summary.open_sessions %}, {{ daily_summary.open_sessions }} still open{% endif %}{% if daily_summary.skipped_sessions %}, {{ daily_summary.skipped_sessions }} skipped{% endif %}.
+            </p>
+          </div>
+          <span class="summary-metric">{{ daily_summary.completion_percentage }}%</span>
+        </div>
+        <div class="progress-track" aria-hidden="true">
+          <span class="progress-fill" style="width: {{ daily_summary.completion_percentage }}%"></span>
+        </div>
+        <dl class="summary-stats">
+          <div>
+            <dt>Completed</dt>
+            <dd>{{ daily_summary.completed_sessions }}</dd>
+          </div>
+          <div>
+            <dt>Open</dt>
+            <dd>{{ daily_summary.open_sessions }}</dd>
+          </div>
+          <div>
+            <dt>Skipped</dt>
+            <dd>{{ daily_summary.skipped_sessions }}</dd>
+          </div>
+        </dl>
+      </section>
+
+      <section class="card summary-card" aria-labelledby="weekly-summary-title">
+        <div class="summary-card-top">
+          <div>
+            <span class="eyebrow">Weekly completion</span>
+            <h2 id="weekly-summary-title">{{ weekly_summary.completed_sessions }}/{{ weekly_summary.total_sessions }}</h2>
+            <p class="summary-range">
+              {{ weekly_summary.week_start|date:"M j" }} - {{ weekly_summary.week_end|date:"M j" }}
+            </p>
+            <p class="summary-copy">
+              {{ weekly_summary.completed_sessions }} session{{ weekly_summary.completed_sessions|pluralize }} completed across this week.
+            </p>
+          </div>
+          <span class="summary-metric">{{ weekly_summary.completion_percentage }}%</span>
+        </div>
+        <div class="progress-track" aria-hidden="true">
+          <span class="progress-fill" style="width: {{ weekly_summary.completion_percentage }}%"></span>
+        </div>
+        <dl class="summary-stats">
+          <div>
+            <dt>Focused days</dt>
+            <dd>{{ weekly_summary.focused_days }}/7</dd>
+          </div>
+          <div>
+            <dt>Full days</dt>
+            <dd>{{ weekly_summary.completed_days }}/7</dd>
+          </div>
+          <div>
+            <dt>Completed</dt>
+            <dd>{{ weekly_summary.completed_sessions }}</dd>
+          </div>
+        </dl>
+      </section>
+
+      <section class="card summary-card" aria-labelledby="consistency-title">
+        <div>
+          <span class="eyebrow">Consistency</span>
+          <h2 id="consistency-title">{{ weekly_summary.streak_days }} day{{ weekly_summary.streak_days|pluralize }}</h2>
+          <p class="summary-copy">
+            {% if weekly_summary.streak_days %}
+              Consecutive days ending on this sheet with at least one completed session.
+            {% else %}
+              Complete one session to start a streak.
+            {% endif %}
+          </p>
+        </div>
+        <dl class="summary-stats">
+          <div>
+            <dt>In progress</dt>
+            <dd>{{ daily_summary.in_progress_sessions }}</dd>
+          </div>
+          <div>
+            <dt>Focused days</dt>
+            <dd>{{ weekly_summary.focused_days }}</dd>
+          </div>
+          <div>
+            <dt>Full days</dt>
+            <dd>{{ weekly_summary.completed_days }}</dd>
+          </div>
+        </dl>
+      </section>
+    </div>
+
     <div class="sheet-grid">
       {% for card in session_cards %}
         {% with session=card.session form=card.form timer=card.timer %}

--- a/templates/core/home.html
+++ b/templates/core/home.html
@@ -47,7 +47,7 @@
             <span class="eyebrow">Daily completion</span>
             <h2 id="daily-summary-title">{{ daily_summary.completed_sessions }}/{{ daily_summary.total_sessions }}</h2>
             <p class="summary-copy">
-              {{ daily_summary.completed_sessions }} session{{ daily_summary.completed_sessions|pluralize }} completed today{% if daily_summary.open_sessions %}, {{ daily_summary.open_sessions }} still open{% endif %}{% if daily_summary.skipped_sessions %}, {{ daily_summary.skipped_sessions }} skipped{% endif %}.
+              {{ daily_summary.completed_sessions }} session{{ daily_summary.completed_sessions|pluralize }} completed {% if is_today %}today{% else %}on this day{% endif %}{% if daily_summary.open_sessions %}, {{ daily_summary.open_sessions }} still open{% endif %}{% if daily_summary.skipped_sessions %}, {{ daily_summary.skipped_sessions }} skipped{% endif %}.
             </p>
           </div>
           <span class="summary-metric">{{ daily_summary.completion_percentage }}%</span>


### PR DESCRIPTION
## Why

The product should reflect the intended routine automatically: 3 personal sessions and 1 admin session each day, with visible progress.

## What changed

- auto-generated daily sheets with default session slots
- enforced the 3 personal + 1 admin default structure
- added daily and weekly completion summaries
- added streak/progress indicators for consistency

## Acceptance criteria

- opening a new day creates the expected default structure
- users can see daily and weekly completion progress
- summary calculations are tested and timezone-aware

## Out of scope

- CSV import/export
- PWA installation
