### PR TITLE
fix(vercel): Align deployment config for Vercel #26

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,4 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+.vercel

--- a/README.md
+++ b/README.md
@@ -156,6 +156,21 @@ The repository now includes the files needed to host the app on Vercel productio
 | `DJANGO_SECURE_HSTS_PRELOAD` | Optional | Optional | Leave unset unless you intentionally want preload and already satisfy the preload requirements (`includeSubDomains` plus at least `31536000` seconds). |
 | `VERCEL_RUN_MIGRATIONS` | Set to `1` only for deliberate schema rollouts | Set to `1` only for isolated preview databases | Build-time migrations are always opt-in. |
 
+#### Generate and add `DJANGO_SECRET_KEY`
+
+1. Generate a secret locally:
+
+   ```bash
+   . .venv/bin/activate
+   python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
+   ```
+
+2. Copy the printed value. Do not commit it or save it in the repository.
+3. In Vercel, open the `deep-workflow` project, then go to **Settings** -> **Environment Variables**.
+4. Create `DJANGO_SECRET_KEY` for the **Preview** environment and paste the copied value.
+5. Generate a second secret the same way and create `DJANGO_SECRET_KEY` for the **Production** environment.
+6. Save the variables and redeploy if a build already failed because the secret was missing.
+
 Vercel injects `VERCEL_ENV`, `VERCEL_URL`, `VERCEL_BRANCH_URL`, and `VERCEL_PROJECT_PRODUCTION_URL` automatically. The app uses those values to allow the current production deployment and each preview deployment without widening `ALLOWED_HOSTS` to every `*.vercel.app` hostname.
 
 ### Production and preview workflow

--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ If `DATABASE_URL` is omitted, Django falls back to SQLite for the quickest local
 The repository now includes the files needed to host the app on Vercel production and PR preview environments:
 
 - `wsgi.py` exposes the Django WSGI app through Vercel's Python runtime
-- `vercel.json` pins the Python function runtime and build command
+- `.python-version` pins the Python runtime that Vercel should use
+- `vercel.json` sets the Vercel build command and rewrites
 - `scripts/vercel-build.sh` always runs `collectstatic` and only runs migrations when `VERCEL_RUN_MIGRATIONS=1`
 - hosted settings derive trusted hosts and CSRF origins from `APP_BASE_URL` plus Vercel's runtime URLs, then enable HTTPS redirects, secure cookies, conservative HSTS defaults, WhiteNoise static serving, and request-ID-aware logging
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ This repository now includes the foundation plus roadmap slices 1 through 9:
 
 Prerequisites:
 
-- Python 3.12+
+- Python 3.12.x
 - PostgreSQL 16+ if you want local PostgreSQL instead of the default SQLite fallback
 
 Bootstrap the project:
@@ -141,7 +141,7 @@ If `DATABASE_URL` is omitted, Django falls back to SQLite for the quickest local
 The repository now includes the files needed to host the app on Vercel production and PR preview environments:
 
 - `wsgi.py` exposes the Django WSGI app through Vercel's Python runtime
-- `.python-version` pins the Python runtime that Vercel should use
+- `.python-version` pins Vercel to Python 3.12, matching the project's supported local Python 3.12.x runtime
 - `vercel.json` sets the Vercel build command and rewrites
 - `scripts/vercel-build.sh` always runs `collectstatic` and only runs migrations when `VERCEL_RUN_MIGRATIONS=1`
 - hosted settings derive trusted hosts and CSRF origins from `APP_BASE_URL` plus Vercel's runtime URLs, then enable HTTPS redirects, secure cookies, conservative HSTS defaults, WhiteNoise static serving, and request-ID-aware logging

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ The repository now includes the files needed to host the app on Vercel productio
 
 | Variable | Production | Preview | Notes |
 | --- | --- | --- | --- |
-| `DJANGO_SECRET_KEY` | Required | Required | Use a unique secret per environment. |
+| `DJANGO_SECRET_KEY` | Required | Required | Use a unique secret per environment. Hosted builds fail fast until this is set. |
 | `DATABASE_URL` | Required | Required | Point previews at an isolated PostgreSQL database or branch database, not production. |
 | `APP_BASE_URL` | `https://deep-workflow.vercel.app` | Optional | Sets the canonical production URL and anchors the production host/origin configuration. |
 | `DJANGO_SECURE_HSTS_PRELOAD` | Optional | Optional | Leave unset unless you intentionally want preload and already satisfy the preload requirements (`includeSubDomains` plus at least `31536000` seconds). |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,18 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "deep-workflow"
 version = "0.1.0"
 requires-python = ">=3.12,<3.13"
-dependencies = [
-    "Django>=5.2,<5.3",
-    "django-environ>=0.11,<0.12",
-    "psycopg[binary]>=3.2,<3.3",
-    "whitenoise>=6.9,<6.10",
-]
+dynamic = ["dependencies"]
+
+[tool.setuptools]
+packages = ["core", "deep_workflow"]
+
+[tool.setuptools.dynamic]
+dependencies = {file = ["requirements.txt"]}
 
 [tool.ruff]
 target-version = "py312"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.12,<3.13"
 dynamic = ["dependencies"]
 
 [tool.setuptools]
-packages = ["core", "deep_workflow"]
+packages = {find = {include = ["core*", "deep_workflow*"]}}
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,14 @@
+[project]
+name = "deep-workflow"
+version = "0.1.0"
+requires-python = ">=3.12,<3.13"
+dependencies = [
+    "Django>=5.2,<5.3",
+    "django-environ>=0.11,<0.12",
+    "psycopg[binary]>=3.2,<3.3",
+    "whitenoise>=6.9,<6.10",
+]
+
 [tool.ruff]
 target-version = "py312"
 

--- a/scripts/vercel-build.sh
+++ b/scripts/vercel-build.sh
@@ -2,8 +2,9 @@
 set -euo pipefail
 
 vercel_environment="${VERCEL_ENV:-local}"
+vercel_runtime="${VERCEL:-}"
 
-if [[ "$vercel_environment" == "preview" || "$vercel_environment" == "production" ]]; then
+if [[ "$vercel_environment" == "preview" || "$vercel_environment" == "production" || "$vercel_environment" == "development" || "$vercel_runtime" == "1" || "$vercel_runtime" == "true" ]]; then
   if [[ -z "${DJANGO_SECRET_KEY:-}" ]]; then
     echo "DJANGO_SECRET_KEY is required for Vercel ${vercel_environment} builds. Add it to that environment in Vercel project settings, then redeploy." >&2
     exit 1

--- a/scripts/vercel-build.sh
+++ b/scripts/vercel-build.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+vercel_environment="${VERCEL_ENV:-local}"
+
+if [[ "$vercel_environment" == "preview" || "$vercel_environment" == "production" ]]; then
+  if [[ -z "${DJANGO_SECRET_KEY:-}" ]]; then
+    echo "DJANGO_SECRET_KEY is required for Vercel ${vercel_environment} builds. Add it to that environment in Vercel project settings, then redeploy." >&2
+    exit 1
+  fi
+fi
+
 python manage.py collectstatic --noinput
 
 if [[ "${VERCEL_RUN_MIGRATIONS:-0}" == "1" ]]; then

--- a/vercel.json
+++ b/vercel.json
@@ -1,12 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "./scripts/vercel-build.sh",
-  "functions": {
-    "wsgi.py": {
-      "runtime": "python3.12",
-      "excludeFiles": "{.venv/**,__pycache__/**,.pytest_cache/**,.ruff_cache/**,core/tests/**,db.sqlite3}"
-    }
-  },
   "rewrites": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Summary
- remove the unsupported Vercel functions runtime override and keep the root WSGI rewrite
- add project metadata to pyproject.toml so Vercel can resolve Python dependencies with uv
- document the Python runtime source and ignore local .vercel metadata

## Validation
- . .venv/bin/activate && ruff check . && ruff format --check . && python manage.py check && pytest
- npx --yes vercel@50.38.2 build

Closes #26
