### PR TITLE
chore(deploy): Gate hosted SQLite recovery behind explicit flag #31

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Vercel injects `VERCEL_ENV`, `VERCEL_URL`, `VERCEL_BRANCH_URL`, and `VERCEL_PROJ
 
 Normal hosted deploys should continue to fail fast if `DATABASE_URL` is missing or broken. If you need a temporary outage recovery mode, you can opt into the hosted SQLite fallback by setting `DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK=1` alongside a SQLite `DATABASE_URL`.
 
-This mode is for emergency recovery only. It moves sessions and flash messages to signed cookies so the app can run from a bundled SQLite snapshot on Vercel, but it should not replace the normal PostgreSQL-backed production path.
+This mode is for emergency recovery only. It moves sessions and flash messages to signed cookies so the app can run from a bundled SQLite snapshot on Vercel, but it should not replace the normal PostgreSQL-backed production path. Only use it when your session and message payloads are small enough to fit within browser cookie limits, and do not treat the cookie contents as secret: signed cookies are tamper-resistant, but their contents remain readable by the client.
 
 ### Health checks and monitoring hooks
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ The repository now includes the files needed to host the app on Vercel productio
 | `DJANGO_SECRET_KEY` | Required | Required | Use a unique secret per environment. Hosted builds fail fast until this is set. |
 | `DATABASE_URL` | Required | Required | Point previews at an isolated PostgreSQL database or branch database, not production. |
 | `APP_BASE_URL` | `https://deep-workflow.vercel.app` | Optional | Sets the canonical production URL and anchors the production host/origin configuration. |
+| `DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK` | Emergency only | Emergency only | Leave unset for normal deploys. Set to `1` only when intentionally activating the temporary hosted SQLite recovery mode. |
 | `DJANGO_SECURE_HSTS_PRELOAD` | Optional | Optional | Leave unset unless you intentionally want preload and already satisfy the preload requirements (`includeSubDomains` plus at least `31536000` seconds). |
 | `VERCEL_RUN_MIGRATIONS` | Set to `1` only for deliberate schema rollouts | Set to `1` only for isolated preview databases | Build-time migrations are always opt-in. |
 
@@ -180,6 +181,12 @@ Vercel injects `VERCEL_ENV`, `VERCEL_URL`, `VERCEL_BRANCH_URL`, and `VERCEL_PROJ
 3. Set `DJANGO_SECRET_KEY` and `DATABASE_URL` in both Production and Preview. Use a separate preview database if you want preview deployments to run migrations.
 4. Let pushes to non-`main` branches create Preview deployments automatically. Leave `VERCEL_RUN_MIGRATIONS` unset for normal deploys; only turn it on for isolated preview databases or a coordinated production schema rollout, then redeploy intentionally.
 5. After each deployment, check `GET /health/ready/` for database readiness and `GET /health/live/` for the lightweight liveness probe.
+
+#### Emergency hosted SQLite recovery
+
+Normal hosted deploys should continue to fail fast if `DATABASE_URL` is missing or broken. If you need a temporary outage recovery mode, you can opt into the hosted SQLite fallback by setting `DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK=1` alongside a SQLite `DATABASE_URL`.
+
+This mode is for emergency recovery only. It moves sessions and flash messages to signed cookies so the app can run from a bundled SQLite snapshot on Vercel, but it should not replace the normal PostgreSQL-backed production path.
 
 ### Health checks and monitoring hooks
 

--- a/core/tests/test_deployment.py
+++ b/core/tests/test_deployment.py
@@ -1,3 +1,8 @@
+import json
+import os
+import subprocess
+import sys
+
 from django.conf import settings
 
 from deep_workflow.deployment import (
@@ -117,3 +122,58 @@ def test_request_id_middleware_precedes_whitenoise() -> None:
     ) < settings.MIDDLEWARE.index(
         "whitenoise.middleware.WhiteNoiseMiddleware",
     )
+
+
+def load_hosted_sqlite_settings(*, enable_fallback: bool) -> tuple[str, str, str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "DJANGO_DEBUG": "False",
+            "DJANGO_SECRET_KEY": "x" * 64,
+            "VERCEL_ENV": "production",
+            "VERCEL": "1",
+            "DATABASE_URL": "sqlite:///db.sqlite3",
+            "DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK": "1" if enable_fallback else "0",
+        }
+    )
+    command = [
+        sys.executable,
+        "-c",
+        (
+            "import json; "
+            "import deep_workflow.settings as settings; "
+            "print(json.dumps(["
+            "str(settings.HOSTED_SQLITE_FALLBACK), "
+            "getattr(settings, 'SESSION_ENGINE', ''), "
+            "getattr(settings, 'MESSAGE_STORAGE', '')"
+            "]))"
+        ),
+    ]
+    result = subprocess.run(
+        command,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return tuple(json.loads(result.stdout))
+
+
+def test_hosted_sqlite_fallback_is_disabled_by_default() -> None:
+    hosted_sqlite_fallback, session_engine, message_storage = (
+        load_hosted_sqlite_settings(enable_fallback=False)
+    )
+
+    assert hosted_sqlite_fallback == "False"
+    assert session_engine == ""
+    assert message_storage == ""
+
+
+def test_hosted_sqlite_fallback_requires_explicit_opt_in() -> None:
+    hosted_sqlite_fallback, session_engine, message_storage = (
+        load_hosted_sqlite_settings(enable_fallback=True)
+    )
+
+    assert hosted_sqlite_fallback == "True"
+    assert session_engine == "django.contrib.sessions.backends.signed_cookies"
+    assert message_storage == "django.contrib.messages.storage.cookie.CookieStorage"

--- a/core/tests/test_deployment.py
+++ b/core/tests/test_deployment.py
@@ -257,23 +257,37 @@ def test_hosted_sqlite_fallback_requires_explicit_opt_in() -> None:
     assert message_storage == "django.contrib.messages.storage.cookie.CookieStorage"
 
 
-def test_hosted_sqlite_fallback_supports_unset_database_url_with_explicit_opt_in() -> (
-    None
-):
-    hosted_sqlite_fallback, session_engine, message_storage = load_hosted_settings(
-        enable_fallback=True,
-        database_url=None,
+def test_hosted_sqlite_fallback_requires_explicit_database_url() -> None:
+    env = os.environ.copy()
+    env.update(
+        {
+            "DJANGO_DEBUG": "False",
+            "DJANGO_SECRET_KEY": "x" * 64,
+            "VERCEL_ENV": "production",
+            "VERCEL": "1",
+            "DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK": "1",
+        }
+    )
+    env.pop("DATABASE_URL", None)
+    result = subprocess.run(
+        [sys.executable, "-c", "import deep_workflow.settings"],
+        env=env,
+        capture_output=True,
+        text=True,
     )
 
-    assert hosted_sqlite_fallback is True
-    assert session_engine == "django.contrib.sessions.backends.signed_cookies"
-    assert message_storage == "django.contrib.messages.storage.cookie.CookieStorage"
+    assert result.returncode != 0
+    assert "ImproperlyConfigured" in result.stderr
+    assert "Hosted deployments require a valid PostgreSQL DATABASE_URL" in result.stderr
+    assert "Do not use SQLite unless DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK" in (
+        result.stderr
+    )
 
 
 def test_hosted_sqlite_fallback_flag_ignored_for_postgresql() -> None:
     hosted_sqlite_fallback, session_engine, message_storage = load_hosted_settings(
         enable_fallback=True,
-        database_url="postgres://testuser:testpass@localhost:5432/testdb",
+        database_url="postgresql://testuser:testpass@localhost:5432/testdb",
     )
 
     assert hosted_sqlite_fallback is False

--- a/core/tests/test_deployment.py
+++ b/core/tests/test_deployment.py
@@ -124,7 +124,11 @@ def test_request_id_middleware_precedes_whitenoise() -> None:
     )
 
 
-def load_hosted_sqlite_settings(*, enable_fallback: bool) -> tuple[str, str, str]:
+def load_hosted_sqlite_settings(
+    *,
+    enable_fallback: bool,
+    database_url: str = "sqlite:///db.sqlite3",
+) -> tuple[bool, str, str]:
     env = os.environ.copy()
     env.update(
         {
@@ -132,7 +136,7 @@ def load_hosted_sqlite_settings(*, enable_fallback: bool) -> tuple[str, str, str
             "DJANGO_SECRET_KEY": "x" * 64,
             "VERCEL_ENV": "production",
             "VERCEL": "1",
-            "DATABASE_URL": "sqlite:///db.sqlite3",
+            "DATABASE_URL": database_url,
             "DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK": "1" if enable_fallback else "0",
         }
     )
@@ -143,7 +147,7 @@ def load_hosted_sqlite_settings(*, enable_fallback: bool) -> tuple[str, str, str
             "import json; "
             "import deep_workflow.settings as settings; "
             "print(json.dumps(["
-            "str(settings.HOSTED_SQLITE_FALLBACK), "
+            "settings.HOSTED_SQLITE_FALLBACK, "
             "getattr(settings, 'SESSION_ENGINE', ''), "
             "getattr(settings, 'MESSAGE_STORAGE', '')"
             "]))"
@@ -160,13 +164,25 @@ def load_hosted_sqlite_settings(*, enable_fallback: bool) -> tuple[str, str, str
 
 
 def test_hosted_sqlite_fallback_is_disabled_by_default() -> None:
-    hosted_sqlite_fallback, session_engine, message_storage = (
-        load_hosted_sqlite_settings(enable_fallback=False)
+    env = os.environ.copy()
+    env.update(
+        {
+            "DJANGO_DEBUG": "False",
+            "DJANGO_SECRET_KEY": "x" * 64,
+            "VERCEL_ENV": "production",
+            "VERCEL": "1",
+            "DATABASE_URL": "sqlite:///db.sqlite3",
+            "DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK": "0",
+        }
     )
-
-    assert hosted_sqlite_fallback == "False"
-    assert session_engine == ""
-    assert message_storage == ""
+    result = subprocess.run(
+        [sys.executable, "-c", "import deep_workflow.settings"],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "ImproperlyConfigured" in result.stderr
 
 
 def test_hosted_sqlite_fallback_requires_explicit_opt_in() -> None:
@@ -174,6 +190,19 @@ def test_hosted_sqlite_fallback_requires_explicit_opt_in() -> None:
         load_hosted_sqlite_settings(enable_fallback=True)
     )
 
-    assert hosted_sqlite_fallback == "True"
+    assert hosted_sqlite_fallback is True
     assert session_engine == "django.contrib.sessions.backends.signed_cookies"
     assert message_storage == "django.contrib.messages.storage.cookie.CookieStorage"
+
+
+def test_hosted_sqlite_fallback_flag_ignored_for_postgresql() -> None:
+    hosted_sqlite_fallback, session_engine, message_storage = (
+        load_hosted_sqlite_settings(
+            enable_fallback=True,
+            database_url="postgres://user:pass@localhost:5432/mydb",
+        )
+    )
+
+    assert hosted_sqlite_fallback is False
+    assert session_engine == ""
+    assert message_storage == ""

--- a/core/tests/test_deployment.py
+++ b/core/tests/test_deployment.py
@@ -277,9 +277,8 @@ def test_hosted_sqlite_fallback_is_disabled_when_database_url_is_unset() -> None
 
 
 def test_hosted_sqlite_fallback_requires_explicit_opt_in() -> None:
-    hosted_sqlite_fallback, session_engine, message_storage = load_hosted_settings(
-        enable_fallback=True
-    )
+    hosted_settings = load_hosted_settings(enable_fallback=True)
+    hosted_sqlite_fallback, session_engine, message_storage = hosted_settings
 
     assert hosted_sqlite_fallback is True
     assert session_engine == "django.contrib.sessions.backends.signed_cookies"

--- a/core/tests/test_deployment.py
+++ b/core/tests/test_deployment.py
@@ -257,9 +257,7 @@ def test_hosted_sqlite_fallback_requires_explicit_opt_in() -> None:
     assert message_storage == "django.contrib.messages.storage.cookie.CookieStorage"
 
 
-def test_hosted_sqlite_fallback_supports_unset_database_url_with_explicit_opt_in() -> (
-    None
-):
+def test_hosted_sqlite_fallback_supports_unset_database_url_with_explicit_opt_in() -> None:
     hosted_sqlite_fallback, session_engine, message_storage = load_hosted_settings(
         enable_fallback=True,
         database_url=None,

--- a/core/tests/test_deployment.py
+++ b/core/tests/test_deployment.py
@@ -127,7 +127,7 @@ def test_request_id_middleware_precedes_whitenoise() -> None:
 def load_hosted_settings(
     *,
     enable_fallback: bool | None,
-    database_url: str = "sqlite:///db.sqlite3",
+    database_url: str | None = "sqlite:///db.sqlite3",
 ) -> tuple[bool, str, str]:
     env = os.environ.copy()
     env.update(
@@ -136,9 +136,12 @@ def load_hosted_settings(
             "DJANGO_SECRET_KEY": "x" * 64,
             "VERCEL_ENV": "production",
             "VERCEL": "1",
-            "DATABASE_URL": database_url,
         }
     )
+    if database_url is None:
+        env.pop("DATABASE_URL", None)
+    else:
+        env["DATABASE_URL"] = database_url
     if enable_fallback is None:
         env.pop("DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK", None)
     else:
@@ -218,9 +221,48 @@ def test_hosted_sqlite_fallback_is_disabled_by_default_when_flag_is_unset() -> N
     )
 
 
+def test_hosted_sqlite_fallback_is_disabled_when_database_url_is_unset() -> None:
+    env = os.environ.copy()
+    env.update(
+        {
+            "DJANGO_DEBUG": "False",
+            "DJANGO_SECRET_KEY": "x" * 64,
+            "VERCEL_ENV": "production",
+            "VERCEL": "1",
+        }
+    )
+    env.pop("DATABASE_URL", None)
+    env.pop("DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK", None)
+    result = subprocess.run(
+        [sys.executable, "-c", "import deep_workflow.settings"],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "ImproperlyConfigured" in result.stderr
+    assert "Hosted deployments require a valid PostgreSQL DATABASE_URL" in result.stderr
+    assert "Do not use SQLite unless DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK" in (
+        result.stderr
+    )
+
+
 def test_hosted_sqlite_fallback_requires_explicit_opt_in() -> None:
     hosted_sqlite_fallback, session_engine, message_storage = load_hosted_settings(
         enable_fallback=True
+    )
+
+    assert hosted_sqlite_fallback is True
+    assert session_engine == "django.contrib.sessions.backends.signed_cookies"
+    assert message_storage == "django.contrib.messages.storage.cookie.CookieStorage"
+
+
+def test_hosted_sqlite_fallback_supports_unset_database_url_with_explicit_opt_in() -> (
+    None
+):
+    hosted_sqlite_fallback, session_engine, message_storage = load_hosted_settings(
+        enable_fallback=True,
+        database_url=None,
     )
 
     assert hosted_sqlite_fallback is True
@@ -237,3 +279,32 @@ def test_hosted_sqlite_fallback_flag_ignored_for_postgresql() -> None:
     assert hosted_sqlite_fallback is False
     assert session_engine == ""
     assert message_storage == ""
+
+
+def test_hosted_sqlite_fallback_is_not_applied_to_invalid_database_url() -> None:
+    env = os.environ.copy()
+    env.update(
+        {
+            "DJANGO_DEBUG": "False",
+            "DJANGO_SECRET_KEY": "x" * 64,
+            "VERCEL_ENV": "production",
+            "VERCEL": "1",
+            "DATABASE_URL": "not-a-valid-database-url",
+            "DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK": "1",
+        }
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", "import deep_workflow.settings"],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "ImproperlyConfigured" in result.stderr
+    assert "Hosted deployments require a valid PostgreSQL DATABASE_URL" in result.stderr
+    assert "Do not use SQLite unless DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK" in (
+        result.stderr
+    )
+    assert "django.contrib.sessions.backends.signed_cookies" not in result.stderr
+    assert "django.contrib.messages.storage.cookie.CookieStorage" not in result.stderr

--- a/core/tests/test_deployment.py
+++ b/core/tests/test_deployment.py
@@ -126,7 +126,7 @@ def test_request_id_middleware_precedes_whitenoise() -> None:
 
 def load_hosted_settings(
     *,
-    enable_fallback: bool,
+    enable_fallback: bool | None,
     database_url: str = "sqlite:///db.sqlite3",
 ) -> tuple[bool, str, str]:
     env = os.environ.copy()
@@ -137,9 +137,12 @@ def load_hosted_settings(
             "VERCEL_ENV": "production",
             "VERCEL": "1",
             "DATABASE_URL": database_url,
-            "DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK": "1" if enable_fallback else "0",
         }
     )
+    if enable_fallback is None:
+        env.pop("DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK", None)
+    else:
+        env["DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK"] = "1" if enable_fallback else "0"
     command = [
         sys.executable,
         "-c",
@@ -163,7 +166,7 @@ def load_hosted_settings(
     return tuple(json.loads(result.stdout))
 
 
-def test_hosted_sqlite_fallback_is_disabled_by_default() -> None:
+def test_hosted_sqlite_fallback_is_disabled_by_default_when_flag_is_zero() -> None:
     env = os.environ.copy()
     env.update(
         {
@@ -183,6 +186,36 @@ def test_hosted_sqlite_fallback_is_disabled_by_default() -> None:
     )
     assert result.returncode != 0
     assert "ImproperlyConfigured" in result.stderr
+    assert "Hosted deployments require a valid PostgreSQL DATABASE_URL" in result.stderr
+    assert "Do not use SQLite unless DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK" in (
+        result.stderr
+    )
+
+
+def test_hosted_sqlite_fallback_is_disabled_by_default_when_flag_is_unset() -> None:
+    env = os.environ.copy()
+    env.update(
+        {
+            "DJANGO_DEBUG": "False",
+            "DJANGO_SECRET_KEY": "x" * 64,
+            "VERCEL_ENV": "production",
+            "VERCEL": "1",
+            "DATABASE_URL": "sqlite:///db.sqlite3",
+        }
+    )
+    env.pop("DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK", None)
+    result = subprocess.run(
+        [sys.executable, "-c", "import deep_workflow.settings"],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "ImproperlyConfigured" in result.stderr
+    assert "Hosted deployments require a valid PostgreSQL DATABASE_URL" in result.stderr
+    assert "Do not use SQLite unless DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK" in (
+        result.stderr
+    )
 
 
 def test_hosted_sqlite_fallback_requires_explicit_opt_in() -> None:

--- a/core/tests/test_deployment.py
+++ b/core/tests/test_deployment.py
@@ -20,10 +20,11 @@ IMPORT_HOSTED_SETTINGS_COMMAND = (
     "import environ; "
     "environ.Env.read_env = staticmethod(lambda *args, **kwargs: None); "
     "import deep_workflow.settings as settings; "
+    "from django.conf import settings as django_settings; "
     "print(json.dumps(["
     "settings.HOSTED_SQLITE_FALLBACK, "
-    "getattr(settings, 'SESSION_ENGINE', ''), "
-    "getattr(settings, 'MESSAGE_STORAGE', '')"
+    "django_settings.SESSION_ENGINE, "
+    "django_settings.MESSAGE_STORAGE"
     "]))"
 )
 
@@ -144,6 +145,7 @@ def load_hosted_settings(
     env.update(
         {
             "DJANGO_DEBUG": "False",
+            "DJANGO_SETTINGS_MODULE": "deep_workflow.settings",
             "DJANGO_SECRET_KEY": "x" * 64,
             "VERCEL_ENV": "production",
             "VERCEL": "1",
@@ -326,8 +328,8 @@ def test_hosted_sqlite_fallback_flag_ignored_for_postgresql() -> None:
     )
 
     assert hosted_sqlite_fallback is False
-    assert session_engine == ""
-    assert message_storage == ""
+    assert session_engine != "django.contrib.sessions.backends.signed_cookies"
+    assert message_storage != "django.contrib.messages.storage.cookie.CookieStorage"
 
 
 def test_hosted_sqlite_fallback_is_not_applied_to_invalid_database_url() -> None:

--- a/core/tests/test_deployment.py
+++ b/core/tests/test_deployment.py
@@ -257,7 +257,9 @@ def test_hosted_sqlite_fallback_requires_explicit_opt_in() -> None:
     assert message_storage == "django.contrib.messages.storage.cookie.CookieStorage"
 
 
-def test_hosted_sqlite_fallback_supports_unset_database_url_with_explicit_opt_in() -> None:
+def test_hosted_sqlite_fallback_supports_unset_database_url_with_explicit_opt_in() -> (
+    None
+):
     hosted_sqlite_fallback, session_engine, message_storage = load_hosted_settings(
         enable_fallback=True,
         database_url=None,

--- a/core/tests/test_deployment.py
+++ b/core/tests/test_deployment.py
@@ -289,7 +289,7 @@ def test_hosted_sqlite_fallback_is_not_applied_to_invalid_database_url() -> None
             "DJANGO_SECRET_KEY": "x" * 64,
             "VERCEL_ENV": "production",
             "VERCEL": "1",
-            "DATABASE_URL": "not-a-valid-database-url",
+            "DATABASE_URL": "invalid://definitely-not-a-supported-database-url",
             "DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK": "1",
         }
     )

--- a/core/tests/test_deployment.py
+++ b/core/tests/test_deployment.py
@@ -27,6 +27,11 @@ IMPORT_HOSTED_SETTINGS_COMMAND = (
     "django_settings.MESSAGE_STORAGE"
     "]))"
 )
+IMPORT_HOSTED_SETTINGS_SNIPPET = (
+    "import environ; "
+    "environ.Env.read_env = staticmethod(lambda *args, **kwargs: None); "
+    "import deep_workflow.settings"
+)
 
 
 def test_build_allowed_hosts_adds_vercel_runtime_hosts() -> None:
@@ -174,7 +179,11 @@ def load_hosted_settings(
     return tuple(json.loads(result.stdout))
 
 
-def test_hosted_sqlite_fallback_is_disabled_by_default_when_flag_is_zero() -> None:
+def run_hosted_settings_import(
+    *,
+    database_url: str | None,
+    enable_fallback: bool | None,
+) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     env.update(
         {
@@ -182,98 +191,61 @@ def test_hosted_sqlite_fallback_is_disabled_by_default_when_flag_is_zero() -> No
             "DJANGO_SECRET_KEY": "x" * 64,
             "VERCEL_ENV": "production",
             "VERCEL": "1",
-            "DATABASE_URL": "sqlite:///db.sqlite3",
-            "DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK": "0",
         }
     )
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-c",
-            (
-                "import environ; "
-                "environ.Env.read_env = staticmethod(lambda *args, **kwargs: None); "
-                "import deep_workflow.settings"
-            ),
-        ],
+    if database_url is None:
+        env.pop("DATABASE_URL", None)
+    else:
+        env["DATABASE_URL"] = database_url
+    if enable_fallback is None:
+        env.pop("DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK", None)
+    else:
+        env["DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK"] = "1" if enable_fallback else "0"
+    return subprocess.run(
+        [sys.executable, "-c", IMPORT_HOSTED_SETTINGS_SNIPPET],
         env=env,
         capture_output=True,
         text=True,
     )
+
+
+def test_hosted_sqlite_fallback_is_disabled_by_default_when_flag_is_zero() -> None:
+    result = run_hosted_settings_import(
+        database_url="sqlite:///db.sqlite3",
+        enable_fallback=False,
+    )
     assert result.returncode != 0
     assert "ImproperlyConfigured" in result.stderr
-    assert "Hosted deployments require a valid PostgreSQL DATABASE_URL" in result.stderr
-    assert "Do not use SQLite unless DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK" in (
+    assert "Hosted deployments require one of these database configurations" in (
         result.stderr
     )
+    assert "DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK=1" in result.stderr
 
 
 def test_hosted_sqlite_fallback_is_disabled_by_default_when_flag_is_unset() -> None:
-    env = os.environ.copy()
-    env.update(
-        {
-            "DJANGO_DEBUG": "False",
-            "DJANGO_SECRET_KEY": "x" * 64,
-            "VERCEL_ENV": "production",
-            "VERCEL": "1",
-            "DATABASE_URL": "sqlite:///db.sqlite3",
-        }
-    )
-    env.pop("DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK", None)
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-c",
-            (
-                "import environ; "
-                "environ.Env.read_env = staticmethod(lambda *args, **kwargs: None); "
-                "import deep_workflow.settings"
-            ),
-        ],
-        env=env,
-        capture_output=True,
-        text=True,
+    result = run_hosted_settings_import(
+        database_url="sqlite:///db.sqlite3",
+        enable_fallback=None,
     )
     assert result.returncode != 0
     assert "ImproperlyConfigured" in result.stderr
-    assert "Hosted deployments require a valid PostgreSQL DATABASE_URL" in result.stderr
-    assert "Do not use SQLite unless DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK" in (
+    assert "Hosted deployments require one of these database configurations" in (
         result.stderr
     )
+    assert "DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK=1" in result.stderr
 
 
 def test_hosted_sqlite_fallback_is_disabled_when_database_url_is_unset() -> None:
-    env = os.environ.copy()
-    env.update(
-        {
-            "DJANGO_DEBUG": "False",
-            "DJANGO_SECRET_KEY": "x" * 64,
-            "VERCEL_ENV": "production",
-            "VERCEL": "1",
-        }
-    )
-    env.pop("DATABASE_URL", None)
-    env.pop("DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK", None)
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-c",
-            (
-                "import environ; "
-                "environ.Env.read_env = staticmethod(lambda *args, **kwargs: None); "
-                "import deep_workflow.settings"
-            ),
-        ],
-        env=env,
-        capture_output=True,
-        text=True,
+    result = run_hosted_settings_import(
+        database_url=None,
+        enable_fallback=None,
     )
     assert result.returncode != 0
     assert "ImproperlyConfigured" in result.stderr
-    assert "Hosted deployments require a valid PostgreSQL DATABASE_URL" in result.stderr
-    assert "Do not use SQLite unless DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK" in (
+    assert "Hosted deployments require one of these database configurations" in (
         result.stderr
     )
+    assert "DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK=1" in result.stderr
 
 
 def test_hosted_sqlite_fallback_requires_explicit_opt_in() -> None:
@@ -286,38 +258,16 @@ def test_hosted_sqlite_fallback_requires_explicit_opt_in() -> None:
 
 
 def test_hosted_sqlite_fallback_requires_explicit_database_url() -> None:
-    env = os.environ.copy()
-    env.update(
-        {
-            "DJANGO_DEBUG": "False",
-            "DJANGO_SECRET_KEY": "x" * 64,
-            "VERCEL_ENV": "production",
-            "VERCEL": "1",
-            "DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK": "1",
-        }
+    result = run_hosted_settings_import(
+        database_url=None,
+        enable_fallback=True,
     )
-    env.pop("DATABASE_URL", None)
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-c",
-            (
-                "import environ; "
-                "environ.Env.read_env = staticmethod(lambda *args, **kwargs: None); "
-                "import deep_workflow.settings"
-            ),
-        ],
-        env=env,
-        capture_output=True,
-        text=True,
-    )
-
     assert result.returncode != 0
     assert "ImproperlyConfigured" in result.stderr
-    assert "Hosted deployments require a valid PostgreSQL DATABASE_URL" in result.stderr
-    assert "Do not use SQLite unless DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK" in (
+    assert "Hosted deployments require one of these database configurations" in (
         result.stderr
     )
+    assert "DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK=1" in result.stderr
 
 
 def test_hosted_sqlite_fallback_flag_ignored_for_postgresql() -> None:
@@ -360,9 +310,9 @@ def test_hosted_sqlite_fallback_is_not_applied_to_invalid_database_url() -> None
 
     assert result.returncode != 0
     assert "ImproperlyConfigured" in result.stderr
-    assert "Hosted deployments require a valid PostgreSQL DATABASE_URL" in result.stderr
-    assert "Do not use SQLite unless DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK" in (
+    assert "Hosted deployments require one of these database configurations" in (
         result.stderr
     )
+    assert "DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK=1" in result.stderr
     assert "django.contrib.sessions.backends.signed_cookies" not in result.stderr
     assert "django.contrib.messages.storage.cookie.CookieStorage" not in result.stderr

--- a/core/tests/test_deployment.py
+++ b/core/tests/test_deployment.py
@@ -16,6 +16,17 @@ from deep_workflow.deployment import (
     hsts_preload_enabled,
 )
 
+IMPORT_HOSTED_SETTINGS_COMMAND = (
+    "import environ; "
+    "environ.Env.read_env = staticmethod(lambda *args, **kwargs: None); "
+    "import deep_workflow.settings as settings; "
+    "print(json.dumps(["
+    "settings.HOSTED_SQLITE_FALLBACK, "
+    "getattr(settings, 'SESSION_ENGINE', ''), "
+    "getattr(settings, 'MESSAGE_STORAGE', '')"
+    "]))"
+)
+
 
 def test_build_allowed_hosts_adds_vercel_runtime_hosts() -> None:
     environ = {
@@ -149,15 +160,7 @@ def load_hosted_settings(
     command = [
         sys.executable,
         "-c",
-        (
-            "import json; "
-            "import deep_workflow.settings as settings; "
-            "print(json.dumps(["
-            "settings.HOSTED_SQLITE_FALLBACK, "
-            "getattr(settings, 'SESSION_ENGINE', ''), "
-            "getattr(settings, 'MESSAGE_STORAGE', '')"
-            "]))"
-        ),
+        f"import json; {IMPORT_HOSTED_SETTINGS_COMMAND}",
     ]
     result = subprocess.run(
         command,
@@ -182,7 +185,15 @@ def test_hosted_sqlite_fallback_is_disabled_by_default_when_flag_is_zero() -> No
         }
     )
     result = subprocess.run(
-        [sys.executable, "-c", "import deep_workflow.settings"],
+        [
+            sys.executable,
+            "-c",
+            (
+                "import environ; "
+                "environ.Env.read_env = staticmethod(lambda *args, **kwargs: None); "
+                "import deep_workflow.settings"
+            ),
+        ],
         env=env,
         capture_output=True,
         text=True,
@@ -208,7 +219,15 @@ def test_hosted_sqlite_fallback_is_disabled_by_default_when_flag_is_unset() -> N
     )
     env.pop("DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK", None)
     result = subprocess.run(
-        [sys.executable, "-c", "import deep_workflow.settings"],
+        [
+            sys.executable,
+            "-c",
+            (
+                "import environ; "
+                "environ.Env.read_env = staticmethod(lambda *args, **kwargs: None); "
+                "import deep_workflow.settings"
+            ),
+        ],
         env=env,
         capture_output=True,
         text=True,
@@ -234,7 +253,15 @@ def test_hosted_sqlite_fallback_is_disabled_when_database_url_is_unset() -> None
     env.pop("DATABASE_URL", None)
     env.pop("DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK", None)
     result = subprocess.run(
-        [sys.executable, "-c", "import deep_workflow.settings"],
+        [
+            sys.executable,
+            "-c",
+            (
+                "import environ; "
+                "environ.Env.read_env = staticmethod(lambda *args, **kwargs: None); "
+                "import deep_workflow.settings"
+            ),
+        ],
         env=env,
         capture_output=True,
         text=True,
@@ -270,7 +297,15 @@ def test_hosted_sqlite_fallback_requires_explicit_database_url() -> None:
     )
     env.pop("DATABASE_URL", None)
     result = subprocess.run(
-        [sys.executable, "-c", "import deep_workflow.settings"],
+        [
+            sys.executable,
+            "-c",
+            (
+                "import environ; "
+                "environ.Env.read_env = staticmethod(lambda *args, **kwargs: None); "
+                "import deep_workflow.settings"
+            ),
+        ],
         env=env,
         capture_output=True,
         text=True,
@@ -308,7 +343,15 @@ def test_hosted_sqlite_fallback_is_not_applied_to_invalid_database_url() -> None
         }
     )
     result = subprocess.run(
-        [sys.executable, "-c", "import deep_workflow.settings"],
+        [
+            sys.executable,
+            "-c",
+            (
+                "import environ; "
+                "environ.Env.read_env = staticmethod(lambda *args, **kwargs: None); "
+                "import deep_workflow.settings"
+            ),
+        ],
         env=env,
         capture_output=True,
         text=True,

--- a/core/tests/test_deployment.py
+++ b/core/tests/test_deployment.py
@@ -124,7 +124,7 @@ def test_request_id_middleware_precedes_whitenoise() -> None:
     )
 
 
-def load_hosted_sqlite_settings(
+def load_hosted_settings(
     *,
     enable_fallback: bool,
     database_url: str = "sqlite:///db.sqlite3",
@@ -186,8 +186,8 @@ def test_hosted_sqlite_fallback_is_disabled_by_default() -> None:
 
 
 def test_hosted_sqlite_fallback_requires_explicit_opt_in() -> None:
-    hosted_sqlite_fallback, session_engine, message_storage = (
-        load_hosted_sqlite_settings(enable_fallback=True)
+    hosted_sqlite_fallback, session_engine, message_storage = load_hosted_settings(
+        enable_fallback=True
     )
 
     assert hosted_sqlite_fallback is True
@@ -196,11 +196,9 @@ def test_hosted_sqlite_fallback_requires_explicit_opt_in() -> None:
 
 
 def test_hosted_sqlite_fallback_flag_ignored_for_postgresql() -> None:
-    hosted_sqlite_fallback, session_engine, message_storage = (
-        load_hosted_sqlite_settings(
-            enable_fallback=True,
-            database_url="postgres://user:pass@localhost:5432/mydb",
-        )
+    hosted_sqlite_fallback, session_engine, message_storage = load_hosted_settings(
+        enable_fallback=True,
+        database_url="postgres://testuser:testpass@localhost:5432/testdb",
     )
 
     assert hosted_sqlite_fallback is False

--- a/deep_workflow/settings.py
+++ b/deep_workflow/settings.py
@@ -113,18 +113,18 @@ DATABASES = {
 }
 DATABASES["default"]["CONN_MAX_AGE"] = env.int("DJANGO_DB_CONN_MAX_AGE", default=60)
 DATABASES["default"]["CONN_HEALTH_CHECKS"] = True
-RAW_DATABASE_URL = os.environ.get("DATABASE_URL", "").strip()
-DATABASE_ENGINE = DATABASES["default"].get("ENGINE")
+raw_database_url = os.environ.get("DATABASE_URL", "").strip()
+database_engine = DATABASES["default"].get("ENGINE")
 HOSTED_SQLITE_FALLBACK = (
     HOSTED_ENV
     and env.bool("DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK")
-    and bool(RAW_DATABASE_URL)
-    and DATABASE_ENGINE == "django.db.backends.sqlite3"
+    and bool(raw_database_url)
+    and database_engine == "django.db.backends.sqlite3"
 )
 
 if (
     HOSTED_ENV
-    and DATABASE_ENGINE != "django.db.backends.postgresql"
+    and database_engine != "django.db.backends.postgresql"
     and not HOSTED_SQLITE_FALLBACK
 ):
     raise ImproperlyConfigured(
@@ -133,7 +133,7 @@ if (
         "is enabled for emergency recovery."
     )
 
-if HOSTED_ENV and DATABASE_ENGINE == "django.db.backends.postgresql":
+if HOSTED_ENV and database_engine == "django.db.backends.postgresql":
     DATABASES["default"].setdefault("OPTIONS", {})
     DATABASES["default"]["OPTIONS"].setdefault(
         "sslmode",

--- a/deep_workflow/settings.py
+++ b/deep_workflow/settings.py
@@ -32,6 +32,7 @@ env = environ.Env(
     DJANGO_DB_CONN_MAX_AGE=(int, 60),
     DJANGO_DB_SSL_MODE=(str, "require"),
     DJANGO_DEBUG=(bool, DEFAULT_DEBUG),
+    DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK=(bool, False),
     DJANGO_LOG_LEVEL=(str, "DEBUG" if DEFAULT_DEBUG else "INFO"),
     DJANGO_REQUEST_LOG_LEVEL=(str, "WARNING"),
     DJANGO_SECRET_KEY=(str, "unsafe-local-development-key"),
@@ -112,6 +113,11 @@ DATABASES = {
 }
 DATABASES["default"]["CONN_MAX_AGE"] = env.int("DJANGO_DB_CONN_MAX_AGE", default=60)
 DATABASES["default"]["CONN_HEALTH_CHECKS"] = True
+HOSTED_SQLITE_FALLBACK = (
+    HOSTED_ENV
+    and env.bool("DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK")
+    and DATABASES["default"]["ENGINE"] == "django.db.backends.sqlite3"
+)
 
 if HOSTED_ENV and DATABASES["default"]["ENGINE"] == "django.db.backends.postgresql":
     DATABASES["default"].setdefault("OPTIONS", {})
@@ -210,6 +216,10 @@ WHITENOISE_USE_FINDERS = DEBUG
 LOGIN_URL = "login"
 LOGIN_REDIRECT_URL = "home"
 LOGOUT_REDIRECT_URL = "login"
+
+if HOSTED_SQLITE_FALLBACK:
+    SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
+    MESSAGE_STORAGE = "django.contrib.messages.storage.cookie.CookieStorage"
 
 LOG_LEVEL = env("DJANGO_LOG_LEVEL").upper()
 REQUEST_LOG_LEVEL = env("DJANGO_REQUEST_LOG_LEVEL").upper()

--- a/deep_workflow/settings.py
+++ b/deep_workflow/settings.py
@@ -119,6 +119,16 @@ HOSTED_SQLITE_FALLBACK = (
     and DATABASES["default"]["ENGINE"] == "django.db.backends.sqlite3"
 )
 
+if (
+    HOSTED_ENV
+    and DATABASES["default"]["ENGINE"] == "django.db.backends.sqlite3"
+    and not HOSTED_SQLITE_FALLBACK
+):
+    raise ImproperlyConfigured(
+        "Hosted deployments must not use SQLite unless "
+        "DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK is enabled."
+    )
+
 if HOSTED_ENV and DATABASES["default"]["ENGINE"] == "django.db.backends.postgresql":
     DATABASES["default"].setdefault("OPTIONS", {})
     DATABASES["default"]["OPTIONS"].setdefault(

--- a/deep_workflow/settings.py
+++ b/deep_workflow/settings.py
@@ -65,9 +65,10 @@ if not DEBUG and SECRET_KEY == "unsafe-local-development-key":
     raise ImproperlyConfigured("Set DJANGO_SECRET_KEY before disabling DJANGO_DEBUG.")
 
 HOSTED_DATABASE_CONFIGURATION_ERROR = (
-    "Hosted deployments require a valid PostgreSQL DATABASE_URL. "
-    "Do not use SQLite unless DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK "
-    "is enabled for emergency recovery."
+    "Hosted deployments require one of these database configurations: "
+    "(1) a valid PostgreSQL DATABASE_URL; or "
+    "(2) for emergency recovery only, DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK=1 "
+    "together with an explicit SQLite DATABASE_URL."
 )
 
 INSTALLED_APPS = [

--- a/deep_workflow/settings.py
+++ b/deep_workflow/settings.py
@@ -113,15 +113,16 @@ DATABASES = {
 }
 DATABASES["default"]["CONN_MAX_AGE"] = env.int("DJANGO_DB_CONN_MAX_AGE", default=60)
 DATABASES["default"]["CONN_HEALTH_CHECKS"] = True
+DATABASE_ENGINE = DATABASES["default"].get("ENGINE")
 HOSTED_SQLITE_FALLBACK = (
     HOSTED_ENV
     and env.bool("DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK")
-    and DATABASES["default"]["ENGINE"] == "django.db.backends.sqlite3"
+    and DATABASE_ENGINE == "django.db.backends.sqlite3"
 )
 
 if (
     HOSTED_ENV
-    and DATABASES["default"]["ENGINE"] == "django.db.backends.sqlite3"
+    and DATABASE_ENGINE != "django.db.backends.postgresql"
     and not HOSTED_SQLITE_FALLBACK
 ):
     raise ImproperlyConfigured(
@@ -130,7 +131,7 @@ if (
         "is enabled for emergency recovery."
     )
 
-if HOSTED_ENV and DATABASES["default"]["ENGINE"] == "django.db.backends.postgresql":
+if HOSTED_ENV and DATABASE_ENGINE == "django.db.backends.postgresql":
     DATABASES["default"].setdefault("OPTIONS", {})
     DATABASES["default"]["OPTIONS"].setdefault(
         "sslmode",

--- a/deep_workflow/settings.py
+++ b/deep_workflow/settings.py
@@ -113,10 +113,12 @@ DATABASES = {
 }
 DATABASES["default"]["CONN_MAX_AGE"] = env.int("DJANGO_DB_CONN_MAX_AGE", default=60)
 DATABASES["default"]["CONN_HEALTH_CHECKS"] = True
+RAW_DATABASE_URL = os.environ.get("DATABASE_URL", "").strip()
 DATABASE_ENGINE = DATABASES["default"].get("ENGINE")
 HOSTED_SQLITE_FALLBACK = (
     HOSTED_ENV
     and env.bool("DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK")
+    and bool(RAW_DATABASE_URL)
     and DATABASE_ENGINE == "django.db.backends.sqlite3"
 )
 

--- a/deep_workflow/settings.py
+++ b/deep_workflow/settings.py
@@ -125,8 +125,9 @@ if (
     and not HOSTED_SQLITE_FALLBACK
 ):
     raise ImproperlyConfigured(
-        "Hosted deployments must not use SQLite unless "
-        "DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK is enabled."
+        "Hosted deployments require a valid PostgreSQL DATABASE_URL. "
+        "Do not use SQLite unless DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK "
+        "is enabled for emergency recovery."
     )
 
 if HOSTED_ENV and DATABASES["default"]["ENGINE"] == "django.db.backends.postgresql":

--- a/deep_workflow/settings.py
+++ b/deep_workflow/settings.py
@@ -64,6 +64,12 @@ CSRF_TRUSTED_ORIGINS = build_csrf_trusted_origins(
 if not DEBUG and SECRET_KEY == "unsafe-local-development-key":
     raise ImproperlyConfigured("Set DJANGO_SECRET_KEY before disabling DJANGO_DEBUG.")
 
+HOSTED_DATABASE_CONFIGURATION_ERROR = (
+    "Hosted deployments require a valid PostgreSQL DATABASE_URL. "
+    "Do not use SQLite unless DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK "
+    "is enabled for emergency recovery."
+)
+
 INSTALLED_APPS = [
     "django.contrib.admin",
     "django.contrib.auth",
@@ -108,9 +114,17 @@ TEMPLATES = [
 WSGI_APPLICATION = "deep_workflow.wsgi.application"
 
 
-DATABASES = {
-    "default": env.db("DATABASE_URL", default=f"sqlite:///{BASE_DIR / 'db.sqlite3'}")
-}
+try:
+    default_database = env.db(
+        "DATABASE_URL",
+        default=f"sqlite:///{BASE_DIR / 'db.sqlite3'}",
+    )
+except ImproperlyConfigured as exc:
+    if HOSTED_ENV:
+        raise ImproperlyConfigured(HOSTED_DATABASE_CONFIGURATION_ERROR) from exc
+    raise
+
+DATABASES = {"default": default_database}
 DATABASES["default"]["CONN_MAX_AGE"] = env.int("DJANGO_DB_CONN_MAX_AGE", default=60)
 DATABASES["default"]["CONN_HEALTH_CHECKS"] = True
 raw_database_url = os.environ.get("DATABASE_URL", "").strip()
@@ -127,11 +141,7 @@ if (
     and database_engine != "django.db.backends.postgresql"
     and not HOSTED_SQLITE_FALLBACK
 ):
-    raise ImproperlyConfigured(
-        "Hosted deployments require a valid PostgreSQL DATABASE_URL. "
-        "Do not use SQLite unless DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK "
-        "is enabled for emergency recovery."
-    )
+    raise ImproperlyConfigured(HOSTED_DATABASE_CONFIGURATION_ERROR)
 
 if HOSTED_ENV and database_engine == "django.db.backends.postgresql":
     DATABASES["default"].setdefault("OPTIONS", {})


### PR DESCRIPTION
## Summary
- require an explicit `DJANGO_ENABLE_HOSTED_SQLITE_FALLBACK=1` opt-in before hosted SQLite recovery activates
- keep normal hosted deployments fail-fast when `DATABASE_URL` is missing or invalid
- document the emergency-only recovery mode and add regression coverage around the flag

## Why
The SQLite rescue path is useful during an outage, but it should never activate silently during normal hosted deploys. This PR keeps the recovery option available while making it a deliberate operator choice.

Closes #31
